### PR TITLE
[CHORE] 도메인 URL 변경 (#17)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -6,7 +6,7 @@
 | Environment | URL |
 |-------------|-----|
 | Local | `http://localhost:8080/api` |
-| Production | `https://finders-api.log8.kr/api` |
+| Production | `https://api.finders.it.kr/api` |
 
 ## Response Format
 

--- a/src/main/java/com/finders/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/finders/api/global/config/SecurityConfig.java
@@ -88,7 +88,8 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOriginPatterns(Arrays.asList(
-                "https://finders-chi.vercel.app",
+                "https://finders.it.kr",
+                "https://www.finders.it.kr",
                 "http://localhost:3000",
                 "http://localhost:5173"
         ));

--- a/src/main/java/com/finders/api/global/config/SwaggerConfig.java
+++ b/src/main/java/com/finders/api/global/config/SwaggerConfig.java
@@ -47,7 +47,7 @@ public class SwaggerConfig {
     private List<Server> servers() {
         return switch (activeProfile) {
             case "prod" -> List.of(
-                    new Server().url("https://finders-api.log8.kr/api").description("Production Server")
+                    new Server().url("https://api.finders.it.kr/api").description("Production Server")
             );
             default -> List.of(
                     new Server().url("http://localhost:8080/api").description("Local Server")


### PR DESCRIPTION
## Summary
새 도메인 `finders.it.kr`로 변경하여 백엔드 API 서버를 `api.finders.it.kr`로 배포합니다.

## Changes
- CORS 설정: `finders-chi.vercel.app` → `finders.it.kr`, `www.finders.it.kr`
- Swagger 서버 URL: `finders-api.log8.kr` → `api.finders.it.kr`
- API 문서(docs/API.md) Production URL 업데이트

## Type of Change
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [x] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
Closes #17

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [x] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes
- Cloudflare Tunnel을 통해 `api.finders.it.kr` 연결 완료
- 프론트엔드 Vercel 도메인 연결은 별도 진행 필요