### PR TITLE
[REFACTOR] JacksonConfig snake_case 설정 제거 (#55)

### DIFF
--- a/src/main/java/com/finders/api/global/config/JacksonConfig.java
+++ b/src/main/java/com/finders/api/global/config/JacksonConfig.java
@@ -1,8 +1,6 @@
 package com.finders.api.global.config;
 
-//import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-//import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
@@ -26,9 +24,6 @@ public class JacksonConfig {
     @Primary
     public ObjectMapper objectMapper() {
         ObjectMapper objectMapper = new ObjectMapper();
-
-//        // Snake Case 설정 (user_name, created_at 등)
-//        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
 
         // Java 8 날짜/시간 지원 (ISO 8601 형식)
         objectMapper.registerModule(new JavaTimeModule());


### PR DESCRIPTION
## Summary
JacksonConfig에서 주석 처리된 snake_case 네이밍 전략 설정 및 관련 미사용 import 문을 제거했습니다.

## Changes
- 주석 처리된 `PropertyNamingStrategies.SNAKE_CASE` 설정 제거
- 미사용 import 문 제거 (`DeserializationFeature`, `PropertyNamingStrategies`)
- JSON 필드명이 DTO 필드명(camelCase)과 동일하게 유지됨

## Type of Change
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [x] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
Closes #55

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes
- 기존에 이미 snake_case 설정이 주석 처리되어 있었음
- 주석으로 남아있던 불필요한 코드를 완전히 제거하여 코드 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)