### PR TITLE
[CHORE] 로컬 개발 환경 .env 파일 자동 로드 설정 (#82)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,11 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     // ========================================
+    // Environment (.env 파일 로드 - 로컬 개발용)
+    // ========================================
+    developmentOnly 'me.paulschwarz:springboot3-dotenv:5.1.0'
+
+    // ========================================
     // Test
     // ========================================
     testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
## Summary
로컬 개발 환경에서 `.env` 파일이 자동으로 로드되도록 `spring-dotenv` 라이브러리를 추가했습니다.

## Changes
- `spring-dotenv` 라이브러리 의존성 추가 (`developmentOnly`)
- 로컬에서 `./gradlew bootRun` 실행 시 프로젝트 루트의 `.env` 파일이 자동 로드됨

## Type of Change
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [x] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
Closes #82

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes
- `developmentOnly`로 추가되어 프로덕션 빌드에는 포함되지 않습니다
- 배포 환경에서는 기존대로 실제 환경변수가 우선 적용됩니다 (docker-compose.prod.yml의 env_file)
- 참고: https://github.com/paulschwarz/spring-dotenv