### PR TITLE
[DOCS] GCP 로깅 가이드에 IntelliJ ADC 설정 및 401 오류 트러블슈팅 추가 (#94)

### DIFF
--- a/docs/infra/GCP_LOGGING_GUIDE.md
+++ b/docs/infra/GCP_LOGGING_GUIDE.md
@@ -127,9 +127,13 @@ gcloud auth application-default login \
 
 ### 4. 애플리케이션 실행
 
+**터미널에서 실행:**
 ```bash
 ./gradlew bootRun
 ```
+
+**IntelliJ에서 실행하는 경우:**
+> ADC 설정 후 **IntelliJ를 완전히 재시작**해야 합니다. (프로젝트 닫기가 아닌 IntelliJ 종료 후 재시작)
 
 ### 5. Swagger에서 테스트
 
@@ -176,6 +180,15 @@ http://localhost:8080/swagger-ui.html 접속 → **[TEST] Storage** 섹션
 - `[TEST] Storage` API는 **local 프로필에서만** 활성화됩니다.
 
 ### 트러블슈팅
+
+#### "401 Unauthorized" 오류
+- ADC 설정이 안 되어 있습니다 → 3번 단계 실행
+- IntelliJ 사용 시 → IntelliJ 완전히 재시작 (종료 후 다시 시작)
+- 기존 ADC가 잘못된 경우:
+  ```bash
+  gcloud auth application-default revoke  # 기존 설정 삭제
+  # 3번 단계 다시 실행
+  ```
 
 #### "403 Forbidden" 오류
 - Impersonation이 만료되었을 수 있습니다 → 3번 단계 다시 실행


### PR DESCRIPTION
## Summary
GCP 로깅 가이드 문서에 IntelliJ 사용자를 위한 ADC 설정 안내와 401 Unauthorized 오류 해결 방법을 추가했습니다.

## Changes
- IntelliJ에서 실행 시 완전 재시작 필요 안내 추가
- 401 Unauthorized 오류 트러블슈팅 섹션 추가 (ADC 미설정, IntelliJ 재시작, 기존 ADC 삭제 방법)

## Type of Change
- [x] Documentation (문서 수정)

## Related Issues
Closes #94

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다

## Additional Notes
로컬 개발 환경에서 GCP Storage 테스트 시 발생할 수 있는 인증 관련 문제를 해결하기 위한 가이드 보완입니다.