### PR TITLE
[FIX] SuccessCode, ErrorCode enum 문법 오류 수정 (#154)

### DIFF
--- a/src/main/java/com/finders/api/global/response/ErrorCode.java
+++ b/src/main/java/com/finders/api/global/response/ErrorCode.java
@@ -151,7 +151,7 @@ public enum ErrorCode implements BaseCode {
     STORAGE_FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "STORAGE_402", "파일 크기가 제한을 초과했습니다."),
     STORAGE_SIGNED_URL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "STORAGE_502", "Signed URL 생성에 실패했습니다."),
     STORAGE_INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "STORAGE_403", "해당 API에서 지원하지 않는 업로드 카테고리입니다."),
-    STORAGE_UNAUTHORIZED(HttpStatus.FORBIDDEN, "STORAGE_405", "해당 경로에 대한 업로드 권한이 없습니다.");
+    STORAGE_UNAUTHORIZED(HttpStatus.FORBIDDEN, "STORAGE_405", "해당 경로에 대한 업로드 권한이 없습니다."),
 
     // ========================================
     // Inquiry (문의)

--- a/src/main/java/com/finders/api/global/response/SuccessCode.java
+++ b/src/main/java/com/finders/api/global/response/SuccessCode.java
@@ -85,7 +85,7 @@ public enum SuccessCode implements BaseCode {
     // ========================================
     STORAGE_UPLOADED(HttpStatus.CREATED, "STORAGE_201", "파일이 업로드되었습니다."),
     STORAGE_DELETED(HttpStatus.OK, "STORAGE_200", "파일이 삭제되었습니다."),
-    STORAGE_UPLOAD_URL_ISSUED(HttpStatus.OK, "FILE_200", "파일 업로드 URL이 발급되었습니다.");
+    STORAGE_UPLOAD_URL_ISSUED(HttpStatus.OK, "FILE_200", "파일 업로드 URL이 발급되었습니다."),
 
     // ========================================
     // Inquiry (문의)


### PR DESCRIPTION
## Summary
PR #141의 CI 빌드 실패 원인이었던 enum 정의 문법 오류를 수정했습니다. enum 상수 중간에 세미콜론(;)이 있어 컴파일 에러가 발생했던 문제를 해결했습니다.

## Changes
- `SuccessCode.java:88` - STORAGE_UPLOAD_URL_ISSUED 뒤 세미콜론(`;`)을 쉼표(`,`)로 변경
- `ErrorCode.java:154` - STORAGE_UNAUTHORIZED 뒤 세미콜론(`;`)을 쉼표(`,`)로 변경
- enum 상수는 쉼표로 구분하고, 마지막 상수만 세미콜론으로 끝나야 함

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
Closes #154

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [x] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [x] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes
- 이 PR은 enum 문법 오류만 수정합니다
- Issue #155 (PhotoLab 관련 StorageService 메서드 호출 실패)는 별도 PR로 처리됩니다 (@joobogyeong 님 할당)
- CI가 실패할 수 있으나, 이는 Issue #155 때문이며 본 PR의 수정사항과는 무관합니다