### PR TITLE
[FIX] 문의 답변 저장 누락 버그 수정 및 Sentry 설정 개선 (#165)

### DIFF
--- a/src/main/java/com/finders/api/domain/inquiry/service/command/InquiryCommandServiceImpl.java
+++ b/src/main/java/com/finders/api/domain/inquiry/service/command/InquiryCommandServiceImpl.java
@@ -5,6 +5,7 @@ import com.finders.api.domain.inquiry.dto.response.InquiryResponse;
 import com.finders.api.domain.inquiry.entity.Inquiry;
 import com.finders.api.domain.inquiry.entity.InquiryReply;
 import com.finders.api.domain.inquiry.enums.InquiryStatus;
+import com.finders.api.domain.inquiry.repository.InquiryReplyRepository;
 import com.finders.api.domain.inquiry.repository.InquiryRepository;
 import com.finders.api.domain.member.entity.Member;
 import com.finders.api.domain.member.repository.MemberRepository;
@@ -22,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class InquiryCommandServiceImpl implements InquiryCommandService {
 
     private final InquiryRepository inquiryRepository;
+    private final InquiryReplyRepository inquiryReplyRepository;
     private final MemberRepository memberRepository;
     private final PhotoLabRepository photoLabRepository;
 
@@ -71,6 +73,7 @@ public class InquiryCommandServiceImpl implements InquiryCommandService {
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         InquiryReply reply = InquiryReply.create(inquiry, replier, request.content());
+        inquiryReplyRepository.save(reply);
 
         return InquiryResponse.ReplyCreateDTO.from(reply);
     }
@@ -92,6 +95,7 @@ public class InquiryCommandServiceImpl implements InquiryCommandService {
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         InquiryReply reply = InquiryReply.create(inquiry, replier, request.content());
+        inquiryReplyRepository.save(reply);
 
         return InquiryResponse.ReplyCreateDTO.from(reply);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -147,6 +147,9 @@ sentry:
   traces-sample-rate: 1.0
   send-default-pii: false
   in-app-includes: com.finders  # 스택트레이스에서 우리 코드 하이라이트
+  logging:
+    minimum-event-level: warn  # WARN 레벨 이상 캡처 (400대 에러 포함)
+    minimum-breadcrumb-level: info  # Breadcrumb은 INFO 레벨부터
 
 # ========================================
 # Logging 설정


### PR DESCRIPTION
## Summary
문의 답변 작성 API에서 발생하는 500 에러를 수정하고, Sentry 설정을 개선했습니다.

## Changes
- `InquiryCommandServiceImpl`에 `InquiryReplyRepository` 의존성 추가
- `createPhotoLabReply()` 메서드에서 InquiryReply 저장 로직 추가 (76번 줄)
- `createServiceReply()` 메서드에서 InquiryReply 저장 로직 추가 (98번 줄)
- Sentry 설정에서 WARN 레벨 이상 이벤트 캡처하도록 개선
  - `logging.minimum-event-level: warn` 추가
  - `logging.minimum-breadcrumb-level: info` 추가

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
Closes #165

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [x] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes
### 버그 원인
InquiryReply 엔티티를 `InquiryReply.create()`로 생성만 하고 `inquiryReplyRepository.save()`를 호출하지 않아서, ID가 null인 상태로 DTO 변환 시 500 에러가 발생했습니다.

### Sentry 설정 개선 이유
기존에는 ERROR 레벨만 캡처하여 400대 에러(WARN 로그)가 Discord로 알림되지 않았습니다. WARN 레벨도 캡처하도록 설정하여 모든 예외를 모니터링할 수 있게 개선했습니다.