### PR TITLE
[FIX] Sentry가 @ExceptionHandler 예외를 캡처하도록 설정 (#177)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -147,6 +147,7 @@ sentry:
   traces-sample-rate: 1.0
   send-default-pii: false
   in-app-includes: com.finders  # 스택트레이스에서 우리 코드 하이라이트
+  exception-resolver-order: -2147483648  # @ExceptionHandler보다 먼저 예외 캡처 (HIGHEST_PRECEDENCE)
   logging:
     minimum-event-level: warn  # WARN 레벨 이상 캡처 (400대 에러 포함)
     minimum-breadcrumb-level: info  # Breadcrumb은 INFO 레벨부터


### PR DESCRIPTION
## Summary
Sentry가 403, 421, 500 등의 에러를 캡처하지 못하는 문제를 해결했습니다. `exception-resolver-order`를 설정하여 @ExceptionHandler보다 Sentry가 먼저 예외를 캡처하도록 변경했습니다.

## Changes
- `application.yml`에 `sentry.exception-resolver-order: -2147483648` 추가
- @ExceptionHandler보다 Sentry가 먼저 예외를 캡처 (HIGHEST_PRECEDENCE)
- 기존 예외 처리 로직은 그대로 유지하면서 Sentry 모니터링 추가

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
Closes #177

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [x] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [x] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes

### 변경 전 동작
```
예외 발생 → @ExceptionHandler에서 처리 → Sentry는 못 봄 ❌
```

### 변경 후 동작
```
예외 발생 → Sentry 캡처 (Order: -2147483648) → @ExceptionHandler 처리 ✅
```

### 참고 자료
- [Sentry Spring Boot - Usage](https://docs.sentry.io/platforms/java/guides/spring-boot/usage/)
- [Error Monitoring in Spring Boot with Sentry](https://tech.bertelsmann.com/en/blog/articles/error-monitoring-in-spring-boot-with-sentry)

### 테스트 방법
1. Prod 환경 배포 후
2. 의도적으로 403, 500 에러 발생시키기
3. Sentry 대시보드에서 이벤트 확인

### 영향 범위
- ✅ 기존 API 응답 형식 변경 없음
- ✅ @ExceptionHandler 동작 그대로 유지
- ✅ Sentry 모니터링만 추가됨