### PR TITLE
[CHORE] logback-spring.xml에 dev 프로필 추가 (#183)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,6 @@ dependencies {
     // ========================================
     implementation platform('com.google.cloud:libraries-bom:26.51.0')
     implementation 'com.google.cloud:google-cloud-storage'
-    implementation 'com.google.cloud:google-cloud-logging-logback'
 
     // ========================================
     // Sentry (Error Monitoring)

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -7,7 +7,8 @@
     <property name="LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n"/>
 
     <!-- ========================================
-         Console Appender (로컬/테스트용)
+         Console Appender
+         - Docker gcplogs 드라이버가 GCP Cloud Logging으로 전송
          ======================================== -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -16,19 +17,7 @@
     </appender>
 
     <!-- ========================================
-         Cloud Logging Appender (GCP 배포용)
-         - Structured JSON 형식으로 Cloud Logging에 전송
-         - 로그 레벨이 Cloud Logging Severity로 자동 매핑됨
-         ======================================== -->
-    <appender name="CLOUD_LOGGING" class="com.google.cloud.logging.logback.LoggingAppender">
-        <!-- 로그 전송 플러시 레벨 (WARNING 이상은 즉시 전송) -->
-        <flushLevel>WARNING</flushLevel>
-        <!-- 추가 레이블 (필터링 시 활용) -->
-        <enhancer>com.google.cloud.logging.logback.TraceLoggingEnhancer</enhancer>
-    </appender>
-
-    <!-- ========================================
-         로컬 프로필: 콘솔 출력
+         로컬 프로필: 콘솔 출력 (상세)
          ======================================== -->
     <springProfile name="local">
         <root level="INFO">
@@ -50,17 +39,27 @@
     </springProfile>
 
     <!-- ========================================
-         운영 프로필: Cloud Logging + 콘솔
-         - Cloud Logging: Structured JSON (필터링/분석용)
-         - Console: Docker logs 백업용
+         개발 프로필: 콘솔 출력 (상세)
+         - Docker gcplogs가 GCP Cloud Logging으로 전송
+         ======================================== -->
+    <springProfile name="dev">
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+        <logger name="com.finders" level="DEBUG"/>
+        <logger name="org.springframework.web" level="INFO"/>
+        <logger name="org.hibernate.SQL" level="DEBUG"/>
+    </springProfile>
+
+    <!-- ========================================
+         운영 프로필: 콘솔 출력 (최소화)
+         - Docker gcplogs가 GCP Cloud Logging으로 전송
          ======================================== -->
     <springProfile name="prod">
         <root level="INFO">
-            <appender-ref ref="CLOUD_LOGGING"/>
             <appender-ref ref="CONSOLE"/>
         </root>
         <logger name="com.finders" level="INFO"/>
-        <!-- 불필요한 로그 제거 -->
         <logger name="org.springframework.web" level="WARN"/>
         <logger name="org.hibernate" level="WARN"/>
     </springProfile>


### PR DESCRIPTION
## Summary
dev 환경에서 로그가 출력되지 않는 문제를 해결하고, 중복된 Cloud Logging 설정을 정리합니다.

## Changes
- logback-spring.xml에 dev 프로필 추가 (CONSOLE appender 연결)
- CLOUD_LOGGING appender 제거 (Docker gcplogs 드라이버로 대체)
- `google-cloud-logging-logback` 의존성 제거

## Type of Change
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [x] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
Closes #183

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Screenshots (Optional)
N/A

## Additional Notes
- Docker gcplogs 드라이버가 이미 GCP Cloud Logging으로 로그를 전송하므로 Logback CLOUD_LOGGING appender는 중복
- PR 머지 후 서버 `.env.dev`, `.env.prod`에서 `GOOGLE_APPLICATION_CREDENTIALS` 줄 삭제 필요