### PR TITLE
[FIX] Docker Compose 프로젝트 이름 충돌 해결 (#185)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -70,12 +70,12 @@ jobs:
             cd ~/app
             echo "${{ secrets.ENV_DEV }}" > .env.dev
 
-            # 2. 최신 이미지 Pull
-            sudo docker compose -f docker-compose.dev.yml pull
+            # 2. 최신 이미지 Pull (-p로 프로젝트 이름 명시: prod와 충돌 방지)
+            sudo docker compose -p finders-dev -f docker-compose.dev.yml pull
 
             # 3. 기존 컨테이너 내리고 새로 시작
-            sudo docker compose -f docker-compose.dev.yml down
-            sudo docker compose -f docker-compose.dev.yml up -d
+            sudo docker compose -p finders-dev -f docker-compose.dev.yml down
+            sudo docker compose -p finders-dev -f docker-compose.dev.yml up -d
 
             # 4. 배포 검증 (Health Check) 로직
             echo "배포 후 Health Check 시작..."
@@ -96,5 +96,5 @@ jobs:
 
             # 5. 실패 시 처리
             echo "❌ 배포 실패: 서비스가 제한 시간 내에 뜨지 않았습니다."
-            sudo docker compose -f docker-compose.dev.yml logs --tail=100
+            sudo docker compose -p finders-dev -f docker-compose.dev.yml logs --tail=100
             exit 1 # GitHub Actions를 '실패(Red)'로 처리

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,12 +71,12 @@ jobs:
             cd ~/app
             echo "${{ secrets.ENV_PROD }}" > .env.prod
             
-            # 2. 최신 이미지 Pull
-            sudo docker compose -f docker-compose.prod.yml pull
-            
+            # 2. 최신 이미지 Pull (-p로 프로젝트 이름 명시: dev와 충돌 방지)
+            sudo docker compose -p finders-prod -f docker-compose.prod.yml pull
+
             # 3. 기존 컨테이너 내리고 새로 시작
-            sudo docker compose -f docker-compose.prod.yml down
-            sudo docker compose -f docker-compose.prod.yml up -d
+            sudo docker compose -p finders-prod -f docker-compose.prod.yml down
+            sudo docker compose -p finders-prod -f docker-compose.prod.yml up -d
             
             # 4. 배포 검증 (Health Check) 로직
             echo "배포 후 Health Check 시작..."
@@ -97,5 +97,5 @@ jobs:
             
             # 5. 실패 시 처리
             echo "❌ 배포 실패: 서비스가 제한 시간 내에 뜨지 않았습니다."
-            sudo docker compose -f docker-compose.prod.yml logs --tail=100
+            sudo docker compose -p finders-prod -f docker-compose.prod.yml logs --tail=100
             exit 1 # GitHub Actions를 '실패(Red)'로 처리

--- a/docs/architecture/INFRASTRUCTURE.md
+++ b/docs/architecture/INFRASTRUCTURE.md
@@ -249,12 +249,19 @@ ssh [사용자]@34.50.19.146
 ```
 
 ### Docker 컨테이너 관리
-```bash
-# Prod 컨테이너 로그
-sudo docker compose -f docker-compose.prod.yml logs -f
 
-# Dev 컨테이너 로그
-sudo docker compose -f docker-compose.dev.yml logs -f
+> **중요**: `-p` 플래그로 프로젝트 이름을 명시해야 dev/prod가 서로 충돌하지 않습니다.
+
+```bash
+# Prod 컨테이너 관리
+sudo docker compose -p finders-prod -f docker-compose.prod.yml logs -f
+sudo docker compose -p finders-prod -f docker-compose.prod.yml down
+sudo docker compose -p finders-prod -f docker-compose.prod.yml up -d
+
+# Dev 컨테이너 관리
+sudo docker compose -p finders-dev -f docker-compose.dev.yml logs -f
+sudo docker compose -p finders-dev -f docker-compose.dev.yml down
+sudo docker compose -p finders-dev -f docker-compose.dev.yml up -d
 
 # 컨테이너 상태 확인
 sudo docker ps

--- a/src/main/java/com/finders/api/global/config/SwaggerConfig.java
+++ b/src/main/java/com/finders/api/global/config/SwaggerConfig.java
@@ -64,6 +64,9 @@ public class SwaggerConfig {
             case "prod" -> List.of(
                     new Server().url("https://api.finders.it.kr/api").description("Production Server")
             );
+            case "dev" -> List.of(
+                    new Server().url("https://dev-api.finders.it.kr/api").description("Development Server")
+            );
             default -> List.of(
                     new Server().url("http://localhost:8080/api").description("Local Server")
             );


### PR DESCRIPTION
## Summary
하나의 GCE에서 dev/prod 동시 배포 시 한쪽이 꺼지는 문제 해결

## Changes
- `deploy.yml`에 `-p finders-prod` 플래그 추가
- `deploy-dev.yml`에 `-p finders-dev` 플래그 추가
- `SwaggerConfig.java`에 dev 프로필 추가 (Swagger URL 문제 해결)
- `INFRASTRUCTURE.md` 문서 업데이트

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)

## Related Issues
Closes #185

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [x] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes
### 문제 원인
`docker compose`가 프로젝트 이름 없이 실행되어 dev/prod가 같은 프로젝트로 인식됨

### 해결 방법
`-p` 플래그로 프로젝트 이름 명시:
- prod: `docker compose -p finders-prod -f docker-compose.prod.yml`
- dev: `docker compose -p finders-dev -f docker-compose.dev.yml`

### 현재 서버 상태
```
✅ https://api.finders.it.kr     → UP (prod)
✅ https://dev-api.finders.it.kr → UP (dev)
```