### PR TITLE
[CHORE] GlobalExceptionHandler에 Sentry 명시적 Exception 캡처 추가 (#191)

### DIFF
--- a/src/main/java/com/finders/api/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/finders/api/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.finders.api.global.exception;
 
 import com.finders.api.global.response.ApiResponse;
 import com.finders.api.global.response.ErrorCode;
+import io.sentry.Sentry;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -132,6 +133,9 @@ public class GlobalExceptionHandler {
             HttpServletRequest request
     ) {
         log.error("[UnhandledException] {} - {}", request.getRequestURI(), e.getMessage(), e);
+
+        // Sentry에 명시적으로 Exception 전송
+        Sentry.captureException(e);
 
         return ResponseEntity
                 .status(ErrorCode.INTERNAL_SERVER_ERROR.getStatus())


### PR DESCRIPTION
## Summary
GlobalExceptionHandler에서 모든 Exception을 처리할 때 Sentry에 명시적으로 Exception을 전송하도록 개선합니다.

## Changes
- GlobalExceptionHandler의 handleException() 메서드에 Sentry.captureException() 추가
- Sentry import 추가 (io.sentry.Sentry)

## Type of Change
- [x] Chore (빌드, 설정 등 기타 변경)
- [x] Refactoring (기능 변경 없는 코드 개선)

## Related Issues
Closes #191

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/development/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [x] Sentry에서 Exception 캡처 확인 완료

## Additional Notes
- Sentry의 exception-resolver-order 설정으로 자동 캡처는 이미 작동 중
- 하지만 명시적 호출로 더 명확하고 context 추가 가능
- Sentry Java SDK 공식 문서에서 권장하는 best practice 적용
- 로그는 기존대로 남고, Sentry에도 명시적으로 전송됨