### PR TITLE
[CHORE] Region 엔티티 자기참조 구조 명확화를 위한 컬럼명 리팩터링 (#200)

### DIFF
--- a/docs/architecture/ERD.md
+++ b/docs/architecture/ERD.md
@@ -526,17 +526,18 @@ CREATE TABLE photo_lab_document
 
 CREATE TABLE region
 (
-    id         BIGINT      NOT NULL AUTO_INCREMENT,
-    regionName    VARCHAR(50) NOT NULL, -- 지역명
-    parentRegion       BIGINT NULL,          -- 시/도 에 해당할 경우 NULL
-    created_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    deleted_at DATETIME NULL,
+    id                BIGINT       NOT NULL AUTO_INCREMENT,
+    region_name       VARCHAR(50)  NOT NULL COMMENT '지역명',
+    parent_region_id  BIGINT       NULL COMMENT '상위 지역 ID (최상위 지역은 NULL)',
+    created_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at        DATETIME     NULL,
     PRIMARY KEY (id),
-    INDEX      idx_region_sido (sido),
-    UNIQUE KEY uk_region_sigungu_sido (sigungu, sido),
-    CONSTRAINT fk_region_sido FOREIGN KEY (sido) REFERENCES region (id)
-) ENGINE=InnoDB COMMENT='지역 (시/도, 시/군/구)';
+    INDEX idx_region_parent (parent_region_id),
+    UNIQUE KEY uk_region_name_parent (region_name, parent_region_id),
+    CONSTRAINT fk_region_parent_region
+        FOREIGN KEY (parent_region_id) REFERENCES region (id)
+) ENGINE=InnoDB COMMENT='지역 (계층 구조: 상위/하위)';
 
 -- ============================================
 -- 3. RESERVATION

--- a/src/main/java/com/finders/api/domain/store/entity/Region.java
+++ b/src/main/java/com/finders/api/domain/store/entity/Region.java
@@ -12,6 +12,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -38,7 +39,8 @@ public class Region extends BaseTimeEntity {
     @Column(name = "region_name", nullable = false, length = 50)
     private String regionName;
 
-    public Region(Region parentRegion, String regionName) {
+    @Builder
+    private Region(Region parentRegion, String regionName) {
         this.parentRegion = parentRegion;
         this.regionName = regionName;
     }

--- a/src/main/java/com/finders/api/global/config/DatabaseSeeder.java
+++ b/src/main/java/com/finders/api/global/config/DatabaseSeeder.java
@@ -321,7 +321,10 @@ public class DatabaseSeeder implements CommandLineRunner {
         // 시/도 생성 (parentRegion = null)
         List<Region> sidoList = new ArrayList<>();
         for (String sidoName : SIDO_NAMES) {
-            Region sido = new Region(null, sidoName);
+            Region sido = Region.builder()
+                    .parentRegion(null)
+                    .regionName(sidoName)
+                    .build();
             sidoList.add(sido);
         }
         regionRepository.saveAll(sidoList);
@@ -330,7 +333,10 @@ public class DatabaseSeeder implements CommandLineRunner {
         List<Region> districtsToSave = new ArrayList<>();
         for (int i = 0; i < sidoList.size(); i++) {
             for (String district : DISTRICT_DATA[i]) {
-                Region region = new Region(sidoList.get(i), district);
+                Region region = Region.builder()
+                        .parentRegion(sidoList.get(i))
+                        .regionName(district)
+                        .build();
                 districtsToSave.add(region);
             }
         }


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
<!-- 변경 사항을 간단히 설명해주세요 -->
Region 엔티티의 컬럼명이 실제 데이터 구조(부모-자식 관계)를 정확히 드러내지 못하고 있어,
자기참조 트리 구조의 의미가 명확하도록 컬럼명과 인덱스를 리팩터링했습니다.

기존 `sido / sigungu` 기반 설계를
`parent_region_id / region_name` 구조로 개선하여
지역 계층 구조를 직관적으로 표현할 수 있도록 수정했습니다.

## Changes
<!-- 변경된 내용을 목록으로 작성해주세요 -->
- Region 엔티티 컬럼명 및 필드명 리팩터링
  - `sido` → `parent_region_id`
  - `sigungu` → `region_name`
- Region 자기참조(`ManyToOne`) 관계 명확화 (`parentRegion`)
- 유니크 인덱스 기준 변경
  - `(region_name, parent_region_id)` 기준으로 동일 상위 지역 내 중복 방지
- 관련 인덱스 이름 정리 및 가독성 개선
- Mock data 업데이트
- ERD.docs 업데이트


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [x] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->
Close #200 

## Checklist
<!-- PR 제출 전 확인사항 -->
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다


## Screenshots (Optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->


## Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
| id | parent_region_id | region_name |
|----|------------------|-------------|
| 1  | null             | 경기도      |
| 2  | 1                | 용인시      |
| 3  | 1                | 화성시      |

- 최상위 지역(시/도)은 `parent_region_id = null`
- 하위 지역(시/군/구)은 상위 지역의 `id`를 `parent_region_id`로 참조
- 이를 통해 지역 계층 구조가 명확하게 표현되며,
  추후 단계 확장(예: 동/읍/면)에도 유연하게 대응할 수 있습니다.
