### PR TITLE
[REFACTOR] InquiryQueryServiceImpl 중복 로직 헬퍼 메서드 추출 (#225)

### DIFF
--- a/src/main/java/com/finders/api/domain/inquiry/service/query/InquiryQueryServiceImpl.java
+++ b/src/main/java/com/finders/api/domain/inquiry/service/query/InquiryQueryServiceImpl.java
@@ -109,7 +109,7 @@ public class InquiryQueryServiceImpl implements InquiryQueryService {
                 .map(storageService::getPublicUrl)
                 .toList();
 
-        log.debug("[InquiryQueryServiceImpl] objectPath → Public URL 변환 완료: inquiryId={}, imageCount={}",
+        log.debug("[InquiryQueryServiceImpl.createInquiryDetailDTOWithPublicUrls] objectPath → Public URL 변환 완료: inquiryId={}, imageCount={}",
                 inquiry.getId(), imageUrls.size());
 
         return InquiryResponse.InquiryDetailDTO.fromWithUrls(inquiry, imageUrls);


### PR DESCRIPTION
## Summary
PR #180 코드 리뷰에서 지적된 중복 로직 문제 해결. `objectPath → Public URL` 변환 로직을 private 헬퍼 메서드로 추출하여 코드 중복 제거.

## Changes
- `createInquiryDetailDTOWithPublicUrls` private 헬퍼 메서드 생성
- `getInquiryDetail`, `getPhotoLabInquiryDetail`, `getServiceInquiryDetail` 3개 메서드에서 헬퍼 메서드 호출로 변경
- 133줄 → 118줄 (15줄 감소)

## Type of Change
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [x] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
Closes #225

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes
- PR #180 리뷰 코멘트: https://github.com/Finders-Official/BE/pull/180#discussion_r2702593517