### PR TITLE
[CHORE] DatabaseSeeder local 프로파일 지원 추가 (#233)

### DIFF
--- a/src/main/java/com/finders/api/global/config/DatabaseSeeder.java
+++ b/src/main/java/com/finders/api/global/config/DatabaseSeeder.java
@@ -57,7 +57,7 @@ import java.util.UUID;
  */
 @Slf4j
 @Component
-@Profile("dev")
+@Profile({"local", "dev"})
 @RequiredArgsConstructor
 public class DatabaseSeeder implements CommandLineRunner {
 


### PR DESCRIPTION
## Summary
로컬 개발 환경(local 프로파일)에서 DatabaseSeeder가 동작하도록 프로파일 설정 추가

## Changes
- `@Profile("dev")` → `@Profile({"local", "dev"})` 로 변경
- local, dev 프로파일 모두에서 DatabaseSeeder 실행 가능

## Type of Change
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [x] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
Closes #233

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Screenshots (Optional)


## Additional Notes
- `docker compose up -d` + `./gradlew bootRun` 실행 시 자동으로 테스트 데이터 생성됨
- 기존 dev 환경 동작에는 영향 없음