### PR TITLE
[FIX] 개발용 토큰 발급 OWNER 지원 및 SecurityConfig 권한 수정 (#239)

### DIFF
--- a/src/main/java/com/finders/api/domain/member/controller/LocalMemberController.java
+++ b/src/main/java/com/finders/api/domain/member/controller/LocalMemberController.java
@@ -1,7 +1,6 @@
 package com.finders.api.domain.member.controller;
 
 import com.finders.api.domain.member.entity.Member;
-import com.finders.api.domain.member.enums.MemberType;
 import com.finders.api.domain.member.repository.MemberRepository;
 import com.finders.api.global.exception.CustomException;
 import com.finders.api.global.response.ApiResponse;
@@ -25,7 +24,7 @@ public class LocalMemberController {
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
 
-    @Operation(summary = "로컬 개발용 토큰 발급", description = "로컬 환경에서는 보안 키 없이 ID를 입력하여 토큰을 발급받습니다.")
+    @Operation(summary = "로컬 개발용 토큰 발급", description = "로컬 환경에서는 보안 키 없이 ID를 입력하여 토큰을 발급받습니다. 모든 role(USER, OWNER, ADMIN) 지원.")
     @GetMapping("/login")
     public ApiResponse<String> devLogin(
             @RequestParam Long memberId
@@ -33,11 +32,7 @@ public class LocalMemberController {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
-        if (member.getRole() != MemberType.USER) {
-            throw new CustomException(ErrorCode.FORBIDDEN);
-        }
-
-        String token = jwtTokenProvider.createAccessToken(memberId, "USER");
+        String token = jwtTokenProvider.createAccessToken(memberId, member.getRole().name());
 
         return ApiResponse.success(SuccessCode.OK, "AccessToken: " + token);
     }

--- a/src/main/java/com/finders/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/finders/api/global/config/SecurityConfig.java
@@ -66,8 +66,7 @@ public class SecurityConfig {
             // HM-010 커뮤니티 사진 미리 보기
             "/posts/preview",
             // 개발용 토큰 발급
-            "/dev/login",
-            "/owner/**"
+            "/dev/login"
     };
 
     @Bean
@@ -102,8 +101,10 @@ public class SecurityConfig {
                         ).hasAnyRole("USER", "GUEST")
                         // GUEST만 허용
                         .requestMatchers("/members/social/signup/complete").hasRole("GUEST")
-                        // USER만 허용
-                        .anyRequest().hasRole("USER")
+                        // OWNER만 허용
+                        .requestMatchers("/owner/**").hasRole("OWNER")
+                        // USER, OWNER 모두 허용 (인증된 사용자)
+                        .anyRequest().hasAnyRole("USER", "OWNER")
                 )
 
                 // JWT 필터 추가


### PR DESCRIPTION
## Summary
- 로컬/개발 환경에서 OWNER role 토큰 발급 가능하도록 수정
- SecurityConfig에서 OWNER 인증 후 API 접근 권한 설정

## Changes
- `LocalMemberController`: USER 제한 제거, `member.getRole().name()` 사용
- `DevMemberController`: MemberRepository 주입, `member.getRole().name()` 사용
- `SecurityConfig`: `/owner/**` PUBLIC에서 제거 후 `hasRole('OWNER')`로 보호
- `SecurityConfig`: `anyRequest()`를 `hasAnyRole('USER', 'OWNER')`로 변경

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)

## Related Issues
Closes #239

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다