### PR TITLE
[FIX] PhotoLab 문서 presigned URL 발급 로직 generate 방식으로 통일 (#244)

### DIFF
--- a/src/main/java/com/finders/api/domain/store/service/PhotoLabDocumentService.java
+++ b/src/main/java/com/finders/api/domain/store/service/PhotoLabDocumentService.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.UUID;
 
 @Slf4j
 @Service
@@ -47,8 +46,13 @@ public class PhotoLabDocumentService {
 
         validateFileName(fileName);
 
-        String objectPath = createDocumentObjectPath(photoLabId, documentType, fileName);
-        return storageService.getPresignedUrl(objectPath, false, null);
+        String documentTypeSegment = documentType.name().toLowerCase();
+        return storageService.generatePresignedUrl(
+                StoragePath.LAB_DOCUMENT,
+                photoLabId,
+                documentTypeSegment,
+                fileName
+        );
     }
 
     @Transactional
@@ -102,10 +106,5 @@ public class PhotoLabDocumentService {
         }
     }
 
-    private String createDocumentObjectPath(Long photoLabId, DocumentType documentType, String fileName) {
-        String uniqueFileName = UUID.randomUUID().toString().replace("-", "") + "_" + fileName;
-        String documentTypeSegment = documentType.name().toLowerCase();
-        return StoragePath.LAB_DOCUMENT.format(photoLabId, documentTypeSegment, uniqueFileName);
-    }
 }
 

--- a/src/main/java/com/finders/api/infra/storage/GcsStorageService.java
+++ b/src/main/java/com/finders/api/infra/storage/GcsStorageService.java
@@ -80,6 +80,18 @@ public class GcsStorageService implements StorageService {
         return getPresignedUrl(objectPath, storagePath.isPublic(), null);
     }
 
+    // 단건 업로드 경로 생성 및 Presigned URL 발급 (subPath 포함)
+    @Override
+    public StorageResponse.PresignedUrl generatePresignedUrl(
+            StoragePath storagePath,
+            Long domainId,
+            String subPath,
+            String originalFileName
+    ) {
+        String objectPath = createUniquePath(storagePath, domainId, subPath, originalFileName);
+        return getPresignedUrl(objectPath, storagePath.isPublic(), null);
+    }
+
     // 벌크 업로드 경로 생성 및 Presigned URL 발급
     @Override
     public List<StorageResponse.PresignedUrl> generateBulkPresignedUrls(StoragePath storagePath, Long domainId, List<String> fileNames) {
@@ -312,6 +324,11 @@ public class GcsStorageService implements StorageService {
     private String createUniquePath(StoragePath storagePath, Long domainId, String fileName) {
         String uniqueFileName = UUID.randomUUID().toString().replace("-", "") + "_" + fileName;
         return storagePath.format(domainId, uniqueFileName);
+    }
+
+    private String createUniquePath(StoragePath storagePath, Long domainId, String subPath, String fileName) {
+        String uniqueFileName = UUID.randomUUID().toString().replace("-", "") + "_" + fileName;
+        return storagePath.format(domainId, subPath, uniqueFileName);
     }
 
     private void validateSignerInitialized() {

--- a/src/main/java/com/finders/api/infra/storage/StorageService.java
+++ b/src/main/java/com/finders/api/infra/storage/StorageService.java
@@ -15,6 +15,9 @@ public interface StorageService {
     // 단건 업로드 경로 생성 및 Presigned URL 발급
     StorageResponse.PresignedUrl generatePresignedUrl(StoragePath storagePath, Long domainId, String originalFileName);
 
+    // Single upload path generation with a subPath (e.g., documentType)
+    StorageResponse.PresignedUrl generatePresignedUrl(StoragePath storagePath, Long domainId, String subPath, String originalFileName);
+
     // 벌크 업로드 경로 생성 및 Presigned URL 발급
     List<StorageResponse.PresignedUrl> generateBulkPresignedUrls(StoragePath storagePath, Long domainId, List<String> fileNames);
 


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
<!-- 변경 사항을 간단히 설명해주세요 -->
photolab document service getPresignedUrl 방식을 photolab image sevice generatePresignedUrl 방식으로 통일

## Changes
<!-- 변경된 내용을 목록으로 작성해주세요 -->
-


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->


## Checklist
<!-- PR 제출 전 확인사항 -->
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다


## Screenshots (Optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->


## Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

