### PR TITLE
[DOCS] GCE OAuth Scope 및 Self-Impersonation 설정 문서화 (#248)

### DIFF
--- a/docs/infra/scripts/grant-iam-permissions.sh.example
+++ b/docs/infra/scripts/grant-iam-permissions.sh.example
@@ -59,6 +59,16 @@ grant_sa_impersonation() {
     echo "    ✓ 완료 (Presigned URL 로컬 테스트 가능)"
 }
 
+grant_sa_self_impersonation() {
+    echo "  → 서비스 계정 Self-Impersonation 권한 부여 중..."
+    echo "    (GCE VM에서 Presigned URL 생성에 필요)"
+    gcloud iam service-accounts add-iam-policy-binding "$SERVICE_ACCOUNT" \
+        --member="serviceAccount:${SERVICE_ACCOUNT}" \
+        --role="roles/iam.serviceAccountTokenCreator" \
+        --quiet > /dev/null 2>&1
+    echo "    ✓ 완료"
+}
+
 # -----------------------------------------------------------------------------
 # 메인 실행
 # -----------------------------------------------------------------------------
@@ -67,6 +77,11 @@ echo "========================================"
 echo "GCP IAM 권한 부여 스크립트"
 echo "프로젝트: ${PROJECT_ID}"
 echo "========================================"
+echo ""
+
+echo "🔐 서비스 계정 Self-Impersonation 설정"
+echo "----------------------------------------"
+grant_sa_self_impersonation
 echo ""
 
 # 팀원 수 확인


### PR DESCRIPTION
## Summary
GCE VM에서 GCS Presigned URL 생성 시 필요한 OAuth Scope와 IAM 권한 설정에 대한 문서를 추가합니다.

## Changes
- GCS-setup.md에 "GCE VM 설정" 섹션 추가
- OAuth Scope 요구사항 (`cloud-platform` 또는 `iam`) 문서화
- Self-Impersonation 권한 설정 방법 추가
- Presigned URL 500 에러 트러블슈팅 섹션 추가

## Type of Change
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [x] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
Closes #248

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes
### 배경
- Dev 서버에서 Presigned URL API 호출 시 500 에러 발생
- 원인: GCE VM의 OAuth Scope에 IAM 관련 scope 누락 + Self-Impersonation 권한 미설정
- 이 문서는 동일한 문제 발생 시 빠른 해결을 위해 작성됨

### 필요한 설정 요약
1. **OAuth Scope**: VM에 `cloud-platform` 또는 `iam` scope 추가
2. **IAM 권한**: 서비스 계정에 `iam.serviceAccountTokenCreator` 역할 부여 (self-impersonation)