### PR TITLE
[FIX] 카카오 약관 동의 조회 시 access token 전달 방식 수정 (#270)

### DIFF
--- a/src/main/java/com/finders/api/domain/auth/service/command/AuthCommandServiceImpl.java
+++ b/src/main/java/com/finders/api/domain/auth/service/command/AuthCommandServiceImpl.java
@@ -54,9 +54,11 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         SocialProvider provider = parseProvider(request.provider());
 
         OAuthClient client = oAuthClientFactory.getOAuthClient(provider);
+
+        String socialAccessToken = request.accessToken();
         OAuthUserInfo userInfo = client.getUserInfo(request.accessToken());
 
-        return resolveSocialLogin(provider, userInfo);
+        return resolveSocialLogin(provider, userInfo, socialAccessToken);
     }
 
     // 카카오 인가 코드로 로그인
@@ -71,11 +73,11 @@ public class AuthCommandServiceImpl implements AuthCommandService {
         OAuthUserInfo userInfo = client.getUserInfo(socialAccessToken);
 
         // 공통 로그인 로직 실행
-        return resolveSocialLogin(provider, userInfo);
+        return resolveSocialLogin(provider, userInfo, socialAccessToken);
     }
 
     // 신규/기존 회원 판별 및 응답 생성
-    private ApiResponse<?> resolveSocialLogin(SocialProvider provider, OAuthUserInfo userInfo) {
+    private ApiResponse<?> resolveSocialLogin(SocialProvider provider, OAuthUserInfo userInfo, String socialAccessToken) {
         SocialAccount socialAccount = socialAccountRepository
                 .findByProviderAndProviderId(provider, userInfo.providerId())
                 .orElse(null);
@@ -85,7 +87,7 @@ public class AuthCommandServiceImpl implements AuthCommandService {
             SignupTokenPayload payload = new SignupTokenPayload(
                     provider,
                     userInfo.providerId(),
-                    userInfo.accessToken(),
+                    socialAccessToken,
                     userInfo.name(),
                     userInfo.nickname(),
                     userInfo.profileImage(),


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
<!-- 변경 사항을 간단히 설명해주세요 -->

카카오 소셜 회원가입 과정에서 약관 동의 내역 조회 시 사용자 access token이 올바르게 전달되지 않던 문제를 수정했습니다.  
SignupToken에 social access token을 포함시키고,  회원가입 완료 단계에서 해당 토큰을 사용해 약관 동의 내역을 조회하도록 개선했습니다.

## Changes
<!-- 변경된 내용을 목록으로 작성해주세요 -->
- SignupTokenPayload에 카카오 social access token 필드 추가
- SignupToken 생성 시 social access token을 함께 저장하도록 수정
- 회원가입 완료 단계에서 providerId 대신 access token 기반으로 약관 조회하도록 변경
- KakaoTermsClient에서 `Bearer access token` 방식으로 인증 헤더 설정
- access token 만료/무효 시 명확한 에러 코드 반환 처리 추가
- RestClient 설정을 활용하도록 약관 조회 API를 상대 경로로 호출하도록 수정

## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->

Fixes #270 

## Checklist
<!-- PR 제출 전 확인사항 -->
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다


## Screenshots (Optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->


## Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

