### PR TITLE
[FIX] StoragePath.fromObjectPath() 복원 경로 매칭 버그 수정 (#287)

### DIFF
--- a/src/test/java/com/finders/api/infra/storage/StoragePathTest.java
+++ b/src/test/java/com/finders/api/infra/storage/StoragePathTest.java
@@ -1,0 +1,132 @@
+package com.finders.api.infra.storage;
+
+import com.finders.api.global.exception.CustomException;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class StoragePathTest {
+
+    @Nested
+    class FromObjectPath {
+
+        @ParameterizedTest
+        @CsvSource({
+                "restorations/65/original/07e3951b92cd40f5ada52981df5e0fb6_photo.png, RESTORATION_ORIGINAL",
+                "restorations/65/mask/07e3951b92cd40f5ada52981df5e0fb6_mask.png, RESTORATION_MASK",
+                "restorations/65/restored/07e3951b92cd40f5ada52981df5e0fb6_restored.png, RESTORATION_RESTORED",
+        })
+        void 복원_경로_original_mask_restored를_정확히_구분한다(String objectPath, StoragePath expected) {
+            assertThat(StoragePath.fromObjectPath(objectPath)).isEqualTo(expected);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "restorations/65/mask/07e3951b92cd40f5ada52981df5e0fb6_mask.png, RESTORATION_MASK",
+                "restorations/65/mask/e83981fef70246fab84bc3ac2a9f2690_mask.png, RESTORATION_MASK",
+                "restorations/65/mask/5388985cd87643cea056c0adb96f9543_mask.png, RESTORATION_MASK",
+                "restorations/65/mask/1f5dff8a4ba5431b9c150ef20ac5a122_mask.png, RESTORATION_MASK",
+                "restorations/65/mask/234e08115a4d4a59afa7d92c6cf1f6ae_mask.png, RESTORATION_MASK",
+                "restorations/65/mask/b59f95a079994d4b8d60f3ebd3347405_mask.png, RESTORATION_MASK",
+        })
+        void 프로덕션_로그에서_실패했던_mask_경로가_올바르게_매칭된다(String objectPath, StoragePath expected) {
+            assertThat(StoragePath.fromObjectPath(objectPath)).isEqualTo(expected);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "restorations/1/original/uuid.png, RESTORATION_ORIGINAL",
+                "restorations/999/original/uuid.png, RESTORATION_ORIGINAL",
+                "restorations/1/mask/uuid.png, RESTORATION_MASK",
+                "restorations/999/mask/uuid.png, RESTORATION_MASK",
+                "restorations/1/restored/uuid.png, RESTORATION_RESTORED",
+                "restorations/999/restored/uuid.png, RESTORATION_RESTORED",
+        })
+        void 다양한_memberId에서도_복원_경로를_구분한다(String objectPath, StoragePath expected) {
+            assertThat(StoragePath.fromObjectPath(objectPath)).isEqualTo(expected);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "photo-labs/1/images/uuid.jpg, LAB_IMAGE",
+                "photo-labs/1/documents/business/uuid.pdf, LAB_DOCUMENT",
+        })
+        void 현상소_이미지와_서류_경로를_구분한다(String objectPath, StoragePath expected) {
+            assertThat(StoragePath.fromObjectPath(objectPath)).isEqualTo(expected);
+        }
+
+        @Test
+        void 현상소_QR코드_경로를_매칭한다() {
+            assertThat(StoragePath.fromObjectPath("photo-labs/1/qr.png")).isEqualTo(StoragePath.LAB_QR);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "profiles/1/uuid.jpg, PROFILE",
+                "posts/1/uuid.jpg, POST_IMAGE",
+                "promotions/1/uuid.jpg, PROMOTION",
+                "inquiries/1/uuid.jpg, INQUIRY",
+                "temp/1/uuid.jpg, TEMP_PUBLIC",
+                "temp/orders/1/scans/uuid.jpg, SCANNED_PHOTO",
+        })
+        void 기타_경로를_올바르게_매칭한다(String objectPath, StoragePath expected) {
+            assertThat(StoragePath.fromObjectPath(objectPath)).isEqualTo(expected);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"  ", "unknown/path/file.jpg", "invalid"})
+        void 유효하지_않은_경로는_예외를_던진다(String objectPath) {
+            assertThatThrownBy(() -> StoragePath.fromObjectPath(objectPath))
+                    .isInstanceOf(CustomException.class);
+        }
+
+        @Test
+        void fromObjectPath와_extractId를_조합하면_올바른_ID를_추출한다() {
+            String maskPath = "restorations/65/mask/uuid_mask.png";
+
+            StoragePath type = StoragePath.fromObjectPath(maskPath);
+            Long memberId = type.extractId(maskPath);
+
+            assertThat(type).isEqualTo(StoragePath.RESTORATION_MASK);
+            assertThat(memberId).isEqualTo(65L);
+        }
+    }
+
+    @Nested
+    class ExtractId {
+
+        @ParameterizedTest
+        @CsvSource({
+                "restorations/65/original/uuid.png, 65",
+                "restorations/123/mask/uuid.png, 123",
+                "restorations/7/restored/uuid.png, 7",
+                "profiles/42/uuid.jpg, 42",
+                "posts/100/uuid.jpg, 100",
+                "inquiries/88/uuid.jpg, 88",
+        })
+        void 경로에서_도메인ID를_추출한다(String objectPath, Long expectedId) {
+            StoragePath type = StoragePath.fromObjectPath(objectPath);
+            assertThat(type.extractId(objectPath)).isEqualTo(expectedId);
+        }
+
+        @Test
+        void 스캔사진_경로에서_주문ID를_추출한다() {
+            assertThat(StoragePath.SCANNED_PHOTO.extractId("temp/orders/42/scans/uuid.jpg"))
+                    .isEqualTo(42L);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"profiles/abc/uuid.jpg", "profiles//uuid.jpg", "restorations"})
+        void ID가_숫자가_아니거나_세그먼트가_부족하면_예외를_던진다(String objectPath) {
+            assertThatThrownBy(() -> StoragePath.PROFILE.extractId(objectPath))
+                    .isInstanceOf(CustomException.class);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`StoragePath.fromObjectPath()`가 root prefix(`restorations`)만 비교하여 `RESTORATION_ORIGINAL`, `RESTORATION_MASK`, `RESTORATION_RESTORED`를 구분하지 못하는 버그를 수정합니다. `findFirst()`가 enum 선언 순서대로 반환하므로 maskPath가 항상 `RESTORATION_ORIGINAL`로 잘못 매칭되어 `POST /restorations` 요청 시 400 에러가 발생했습니다.

## Changes

- `StoragePath.fromObjectPath()`: root prefix 비교 → 고정 세그먼트 기반 best-match 스코어링으로 변경
- `StoragePathTest` 신규 추가 (40개 테스트 케이스)
  - 복원 경로 original/mask/restored 구분 검증
  - 프로덕션 로그에서 실패했던 실제 mask 경로 재현 테스트
  - 현상소 이미지/서류/QR 경로 구분 검증
  - fromObjectPath + extractId 조합 테스트
  - null/empty/invalid 경로 예외 검증

## Type of Change

- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)

## Related Issues

Closes #287

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [x] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes

### 근본 원인

```java
// 변경 전: root prefix만 비교 → restorations/* 3개를 구분 불가
String root = path.getPattern().split("/")[0]; // → "restorations"
return objectPath.startsWith(root);            // 3개 모두 true
// findFirst() → 항상 RESTORATION_ORIGINAL (enum 순서 1번)

// 변경 후: 모든 고정 세그먼트를 비교하여 가장 많이 일치하는 enum 반환
// restorations/65/mask/uuid.png → "restorations" + "mask" = score 2 → RESTORATION_MASK ✅
```

### 프로덕션 에러 로그 (2026-02-06)

```
WARN [CustomException] COMMON_400 - 잘못된 이미지 경로입니다: restorations/65/mask/07e3951b92cd40f5ada52981df5e0fb6_mask.png
WARN [CustomException] COMMON_400 - 잘못된 이미지 경로입니다: restorations/65/mask/e83981fef70246fab84bc3ac2a9f2690_mask.png
(... 10건 이상 반복)
```

### 영향 범위

- `photo-labs` 경로(`LAB_IMAGE` vs `LAB_DOCUMENT` vs `LAB_QR`)도 동일한 root를 공유하지만, 기존 `findFirst()` 순서상 `LAB_IMAGE`가 먼저 반환되어 서류 업로드 쪽에서도 잠재적 버그가 있었습니다. 이번 수정으로 함께 해결됩니다.