### PR TITLE
[FIX] ReplicateClient WebClient 빈 주입 버그 수정 (#289)

### DIFF
--- a/src/main/java/com/finders/api/infra/replicate/ReplicateClient.java
+++ b/src/main/java/com/finders/api/infra/replicate/ReplicateClient.java
@@ -4,6 +4,7 @@ import com.finders.api.global.exception.CustomException;
 import com.finders.api.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.ClientResponse;
@@ -18,6 +19,7 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class ReplicateClient {
 
+    @Qualifier("replicateWebClient")
     private final WebClient replicateWebClient;
     private final ReplicateProperties properties;
 


### PR DESCRIPTION
## Summary

`ReplicateClient`에 `@Primary`인 baseUrl 없는 `WebClient`가 주입되어, Replicate API 호출이 `localhost:80`으로 전송되던 버그를 수정합니다.

## Changes

- `ReplicateClient.replicateWebClient` 필드에 `@Qualifier("replicateWebClient")` 추가

## Type of Change

- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)

## Related Issues

Closes #289

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes

### 근본 원인

Spring 컨테이너에 두 개의 `WebClient` 빈이 존재합니다:

| 빈 이름 | 등록 위치 | baseUrl | @Primary |
|---------|----------|---------|----------|
| `webClient` | `WebClientConfig` | ❌ 없음 | ✅ `@Primary` |
| `replicateWebClient` | `ReplicateConfig` | ✅ `https://api.replicate.com/v1` | ❌ |

`ReplicateClient`에서 `@RequiredArgsConstructor`로 주입 시 `@Primary` 빈이 우선 선택되어, baseUrl 없는 WebClient가 주입됩니다:

```java
// 변경 전: @Primary인 webClient(baseUrl 없음)가 주입됨
private final WebClient replicateWebClient;

// 변경 후: replicateWebClient 빈이 명시적으로 주입됨
@Qualifier("replicateWebClient")
private final WebClient replicateWebClient;
```

### GCP 로그 증거

```
ERROR ReplicateClient - Failed to create prediction: finishConnect(..) failed with error(-111): Connection refused: /[0:0:0:0:0:0:0:1]:80
```

`/[::1]:80` = IPv6 localhost 포트 80 (HTTP 기본) → baseUrl이 없어 상대 경로 `/predictions`가 localhost로 resolve됨