### PR TITLE
[FIX] ReplicateConfig WebClient.Builder 주입 오류 수정 (#294)

### DIFF
--- a/src/main/java/com/finders/api/infra/replicate/ReplicateConfig.java
+++ b/src/main/java/com/finders/api/infra/replicate/ReplicateConfig.java
@@ -15,8 +15,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class ReplicateConfig {
 
     @Bean
-    public WebClient replicateWebClient(ReplicateProperties properties) {
-        return WebClient.builder()
+    public WebClient replicateWebClient(WebClient.Builder builder, ReplicateProperties properties) {
+        return builder
                 .baseUrl(properties.baseUrl())
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + properties.apiKey())
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)


### PR DESCRIPTION
## Summary
ReplicateConfig에서 `WebClient.builder()`를 직접 생성하는 대신 Spring이 관리하는 `WebClient.Builder`를 주입받도록 수정했습니다.

## Changes
- `ReplicateConfig.replicateWebClient()` 메서드에 `WebClient.Builder` 파라미터 추가
- `WebClient.builder()` 직접 호출 제거
- 이제 Spring이 설정한 기본 HttpClient 설정이 적용됩니다

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)

## Related Issues
Closes #294

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes

### 근본 원인
```java
// 변경 전 (잘못됨)
@Bean
public WebClient replicateWebClient(ReplicateProperties properties) {
    return WebClient.builder()  // ❌ 새로운 Builder 생성 (Spring 관리 X)
        .baseUrl(properties.baseUrl())
        .build();
}

// 변경 후 (올바름)
@Bean
public WebClient replicateWebClient(WebClient.Builder builder, ReplicateProperties properties) {
    return builder  // ✅ Spring이 관리하는 Builder 사용
        .baseUrl(properties.baseUrl())
        .build();
}
```

### 에러 로그
```
Connection refused: /[0:0:0:0:0:0:0:1]:80
```

### 연관 이슈
- PR #290에서 `@Qualifier` 추가로 부분 해결 시도
- 하지만 근본 원인은 Builder 생성 방식이었음