### PR TITLE
[REFACTOR] Replicate API 에러 메시지 구체화 (#296)

### DIFF
--- a/src/main/java/com/finders/api/infra/replicate/ReplicateClient.java
+++ b/src/main/java/com/finders/api/infra/replicate/ReplicateClient.java
@@ -51,7 +51,7 @@ public class ReplicateClient {
             throw e;
         } catch (Exception e) {
             log.error("[ReplicateClient.createInpaintingPrediction] Failed to create prediction: {}", e.getMessage(), e);
-            throw new CustomException(ErrorCode.EXTERNAL_API_ERROR, e);
+            throw new CustomException(ErrorCode.EXTERNAL_API_ERROR, "Replicate API 호출 실패: " + e.getMessage());
         }
     }
 
@@ -69,7 +69,7 @@ public class ReplicateClient {
             throw e;
         } catch (Exception e) {
             log.error("[ReplicateClient.getPrediction] Failed to get prediction: {}", e.getMessage(), e);
-            throw new CustomException(ErrorCode.EXTERNAL_API_ERROR, e);
+            throw new CustomException(ErrorCode.EXTERNAL_API_ERROR, "Replicate API 조회 실패: " + e.getMessage());
         }
     }
 


### PR DESCRIPTION
## Summary
Replicate API 호출 실패 시 에러 메시지에 구체적인 원인을 포함하도록 개선했습니다.

## Changes
- `ReplicateClient.createInpaintingPrediction()`: 에러 메시지에 구체적인 원인 포함
- `ReplicateClient.getPrediction()`: 에러 메시지에 구체적인 원인 포함

## Type of Change
- [x] Refactoring (기능 변경 없는 코드 개선)

## Related Issues
Closes #296

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes

### 변경 전
```json
{
  "success": false,
  "code": "EXTERNAL_503",
  "message": "외부 API 호출에 실패했습니다."
}
```

### 변경 후
```json
{
  "success": false,
  "code": "EXTERNAL_503",
  "message": "Replicate API 호출 실패: Connection refused"
}
```

### 효과
- 디버깅 시 구체적인 원인 파악 가능
- GCS 에러와 Replicate 에러 구분 가능
- 트러블슈팅 시간 단축