### PR TITLE
[FIX] ReplicateProperties baseUrl 빈 문자열 처리 추가 (#298)

### DIFF
--- a/src/main/java/com/finders/api/infra/replicate/ReplicateProperties.java
+++ b/src/main/java/com/finders/api/infra/replicate/ReplicateProperties.java
@@ -16,7 +16,7 @@ public record ReplicateProperties(
         Integer maxRetries
 ) {
     public ReplicateProperties {
-        if (baseUrl == null) {
+        if (baseUrl == null || baseUrl.isBlank()) {
             baseUrl = "https://api.replicate.com/v1";
         }
         if (timeoutSeconds == null) {


### PR DESCRIPTION
## Summary
ReplicateProperties에서 baseUrl이 빈 문자열일 때 기본값이 적용되지 않는 버그 수정

## Changes
- `ReplicateProperties` canonical constructor에 `isBlank()` 체크 추가
- baseUrl이 `null` 또는 빈 문자열일 때 기본값 `https://api.replicate.com/v1` 적용

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
Closes #298

## Checklist
- [x] 코드 컨벤션을 준수했습니다
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당 없음)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다 (해당 없음)

## Additional Notes
### 문제 상황
- dev 환경에서 POST /api/restorations API 호출 시 503 에러 발생
- 에러 메시지: `Connection refused: /[0:0:0:0:0:0:0:1]:80`
- WebClient가 localhost:80으로 연결 시도

### 원인
- 환경변수가 빈 문자열로 설정된 경우, `null` 체크만으로는 기본값이 적용되지 않음
- `application.yml`의 `${REPLICATE_API_KEY:}` 형식은 환경변수가 없으면 빈 문자열 반환

### 해결
- `baseUrl == null || baseUrl.isBlank()` 조건으로 변경하여 빈 문자열도 기본값 적용