### PR TITLE
[FEAT] Replicate API 연동 로직 고도화 및 테스트 API 스펙 동기화 (#305)

### DIFF
--- a/src/main/java/com/finders/api/infra/replicate/ReplicateClient.java
+++ b/src/main/java/com/finders/api/infra/replicate/ReplicateClient.java
@@ -25,7 +25,7 @@ public class ReplicateClient {
     }
 
     public ReplicateResponse.Prediction createInpaintingPrediction(String imageUrl, String maskUrl) {
-        log.info(">>> [REPLICATE] Starting prediction request. BaseUrl: {}", properties.baseUrl());
+        log.info("[ReplicateClient.createInpaintingPrediction] Creating prediction");
         
         ReplicateRequest.CreatePrediction request = ReplicateRequest.CreatePrediction.of(
                 properties.modelVersion(),
@@ -44,12 +44,13 @@ public class ReplicateClient {
                     .block();
 
         } catch (Exception e) {
-            log.error(">>> [REPLICATE] Call failed: {}", e.getMessage());
-            throw new CustomException(ErrorCode.EXTERNAL_API_ERROR, "Replicate API 실패: " + e.getMessage());
+            log.error("[ReplicateClient.createInpaintingPrediction] Failed: {}", e.getMessage());
+            throw new CustomException(ErrorCode.EXTERNAL_API_ERROR, "Replicate API 호출 실패: " + e.getMessage());
         }
     }
 
     public ReplicateResponse.Prediction getPrediction(String predictionId) {
+        log.debug("[ReplicateClient.getPrediction] Getting prediction: id={}", predictionId);
         try {
             return replicateWebClient.get()
                     .uri("/predictions/{id}", predictionId)
@@ -58,7 +59,7 @@ public class ReplicateClient {
                     .bodyToMono(ReplicateResponse.Prediction.class)
                     .block();
         } catch (Exception e) {
-            log.error(">>> [REPLICATE] Get failed: {}", e.getMessage());
+            log.error("[ReplicateClient.getPrediction] Failed: {}", e.getMessage());
             throw new CustomException(ErrorCode.EXTERNAL_API_ERROR, "Replicate 조회 실패: " + e.getMessage());
         }
     }
@@ -66,7 +67,7 @@ public class ReplicateClient {
     private Mono<? extends Throwable> handleError(ClientResponse response) {
         return response.bodyToMono(String.class)
                 .flatMap(body -> {
-                    log.error(">>> [REPLICATE] Error response: {} - {}", response.statusCode(), body);
+                    log.error("[ReplicateClient.handleError] Error response: status={}, body={}", response.statusCode(), body);
                     return Mono.error(new CustomException(ErrorCode.EXTERNAL_API_ERROR,
                             "Replicate API error: " + response.statusCode()));
                 });

--- a/src/main/java/com/finders/api/infra/replicate/ReplicateRequest.java
+++ b/src/main/java/com/finders/api/infra/replicate/ReplicateRequest.java
@@ -1,5 +1,6 @@
 package com.finders.api.infra.replicate;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -12,6 +13,7 @@ public class ReplicateRequest {
     /**
      * Prediction 생성 요청
      */
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public record CreatePrediction(
             String version,
             Input input,
@@ -20,11 +22,13 @@ public class ReplicateRequest {
             List<String> webhookEventsFilter
     ) {
         public static CreatePrediction of(String version, String imageUrl, String maskUrl, String webhookUrl) {
+            String finalWebhook = (webhookUrl != null && webhookUrl.startsWith("https://")) ? webhookUrl : null;
+            
             return new CreatePrediction(
                     version,
                     Input.forRestoration(imageUrl, maskUrl),
-                    null,
-                    null
+                    finalWebhook,
+                    finalWebhook != null ? List.of("completed") : null
             );
         }
     }

--- a/src/main/java/com/finders/api/infra/replicate/ReplicateResponse.java
+++ b/src/main/java/com/finders/api/infra/replicate/ReplicateResponse.java
@@ -1,5 +1,6 @@
 package com.finders.api.infra.replicate;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
@@ -12,6 +13,7 @@ public class ReplicateResponse {
     /**
      * Prediction 응답 (API 응답 및 Webhook 페이로드 공용)
      */
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public record Prediction(
             String id,
             String status,


### PR DESCRIPTION
## Summary
- 이전 PR에서 머지된 로직을 실제 운영 API 스펙에 맞춰 보완하고, 연동 안정성을 강화했습니다.

## Changes
- **ReplicateResponse**: 미확인 필드 무시 설정을 추가하여 API 응답 처리 안정성 확보
- **ReplicateRequest**: 로컬 테스트 시 부적절한 Webhook 전송으로 인한 422 에러 방지 로직 추가
- **ReplicateTestController**: 
  - 파라미터명을 실제 운영 API와 동일하게 `originalPath`, `maskPath`로 변경
  - GCS Object Path 입력 시 자동으로 Signed URL로 변환하는 로직 추가

## Type of Change
- [x] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [x] Bug fix (버그 수정)

## Related Issues
- Closes #305

## Checklist
- [x] 실제 Replicate API 호출 테스트를 통해 연동 성공 확인 (200 OK)
- [x] 로컬 환경 및 배포 환경(dev-api) 대응 로직 검증