### PR TITLE
[FIX] Swagger UI 가독성 개선 및 예시 값 추가

### DIFF
--- a/src/main/java/com/finders/api/domain/member/dto/request/MemberAddressRequest.java
+++ b/src/main/java/com/finders/api/domain/member/dto/request/MemberAddressRequest.java
@@ -1,5 +1,6 @@
 package com.finders.api.domain.member.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Builder;
@@ -8,20 +9,26 @@ public class MemberAddressRequest {
 
     @Builder
     public record Create(
+            @Schema(description = "배송지 이름", example = "우리집")
             @NotBlank(message = "배송지 이름은 필수입니다.")
             @Size(max = 50, message = "배송지 이름은 50자 이내여야 합니다.")
             String addressName,
 
+            @Schema(description = "우편번호", example = "06035")
             @NotBlank(message = "우편번호는 필수입니다.")
             @Size(max = 10, message = "우편번호는 10자 이내여야 합니다.")
             String zipcode,
 
+            @Schema(description = "주소", example = "서울특별시 강남구 가로수길 5")
             @NotBlank(message = "주소는 필수입니다.")
             @Size(max = 200, message = "주소는 200자 이내여야 합니다.")
             String address,
 
+            @Schema(description = "상세주소", example = "101동 202호")
             @Size(max = 100, message = "상세주소는 100자 이내여야 합니다.")
             String addressDetail,
+
+            @Schema(description = "기본 배송지 여부", example = "true")
             boolean isDefault
     ) {}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -131,7 +131,7 @@ springdoc:
     path: /v3/api-docs
   default-consumes-media-type: application/json
   default-produces-media-type: application/json
-  use-fqn: true   # DTO 클래스 이름 충돌을 방지하기 위해 FQN(Fully Qualified Name) 사용
+  use-fqn: false   # DTO 클래스 이름 충돌을 방지하기 위해 FQN(Fully Qualified Name) 사용을 해제하고 클래스명만 노출하도록 수정
 
 # ========================================
 # PortOne V2 결제 설정


### PR DESCRIPTION
## Summary
- `application.yml`에서 `springdoc.use-fqn: false`로 설정하여 Schema 탭에서 전체 패키지 경로 대신 클래스명만 노출되도록 개선했습니다.
- `MemberAddressRequest` DTO에 `@Schema`를 추가하여 실제 테스트 가능한 예시 값을 제공합니다.