### PR TITLE
[FEAT] 개발용 SignupToken 발급 API 구현 (#325)

### DIFF
--- a/src/main/java/com/finders/api/domain/member/controller/LocalMemberController.java
+++ b/src/main/java/com/finders/api/domain/member/controller/LocalMemberController.java
@@ -44,8 +44,8 @@ public class LocalMemberController {
     }
 
     @Operation(
-            summary = "로컬 개발용 SignupTiken 발급",
-            description = "dd"
+            summary = "로컬 개발용 SignupToken 발급",
+            description = "로컬 개발 환경에서 OAuth 인증 없이 테스트용 SignupToken을 발급합니다."
     )
     @GetMapping("/signup-token")
     public ResponseEntity<Map<String, String>> getMockSignupToken(

--- a/src/main/java/com/finders/api/domain/member/controller/LocalMemberController.java
+++ b/src/main/java/com/finders/api/domain/member/controller/LocalMemberController.java
@@ -48,7 +48,7 @@ public class LocalMemberController {
             description = "로컬 개발 환경에서 OAuth 인증 없이 테스트용 SignupToken을 발급합니다."
     )
     @GetMapping("/signup-token")
-    public ResponseEntity<Map<String, String>> getMockSignupToken(
+    public ApiResponse<Map<String, String>> getMockSignupToken(
             @RequestParam(defaultValue = "KAKAO") SocialProvider provider,
             @RequestParam(defaultValue = "1") String providerId,
             @RequestParam(defaultValue = "test@kakao.com") String email,
@@ -67,6 +67,6 @@ public class LocalMemberController {
 
         String token = signupTokenProvider.createSignupToken(payload);
 
-        return ResponseEntity.ok(Map.of("signupToken", token));
+        return ApiResponse.success(SuccessCode.OK, Map.of("signupToken", token));
     }
 }

--- a/src/main/java/com/finders/api/domain/member/controller/LocalMemberController.java
+++ b/src/main/java/com/finders/api/domain/member/controller/LocalMemberController.java
@@ -1,18 +1,23 @@
 package com.finders.api.domain.member.controller;
 
+import com.finders.api.domain.auth.dto.SignupTokenPayload;
 import com.finders.api.domain.member.entity.Member;
+import com.finders.api.domain.member.enums.SocialProvider;
 import com.finders.api.domain.member.repository.MemberRepository;
 import com.finders.api.global.exception.CustomException;
 import com.finders.api.global.response.ApiResponse;
 import com.finders.api.global.response.ErrorCode;
 import com.finders.api.global.response.SuccessCode;
 import com.finders.api.global.security.JwtTokenProvider;
+import com.finders.api.global.security.SignupTokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @Tag(name = "개발용 도구", description = "개발 및 테스트를 위한 API")
 @RestController
@@ -22,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 public class LocalMemberController {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final SignupTokenProvider signupTokenProvider;
     private final MemberRepository memberRepository;
 
     @Operation(summary = "로컬 개발용 토큰 발급", description = "로컬 환경에서는 보안 키 없이 ID를 입력하여 토큰을 발급받습니다. 모든 role(USER, OWNER, ADMIN) 지원.")
@@ -35,5 +41,32 @@ public class LocalMemberController {
         String token = jwtTokenProvider.createAccessToken(memberId, member.getRole().name());
 
         return ApiResponse.success(SuccessCode.OK, "AccessToken: " + token);
+    }
+
+    @Operation(
+            summary = "로컬 개발용 SignupTiken 발급",
+            description = "dd"
+    )
+    @GetMapping("/signup-token")
+    public ResponseEntity<Map<String, String>> getMockSignupToken(
+            @RequestParam(defaultValue = "KAKAO") SocialProvider provider,
+            @RequestParam(defaultValue = "1") String providerId,
+            @RequestParam(defaultValue = "test@kakao.com") String email,
+            @RequestParam(defaultValue = "테스트유저") String name,
+            @RequestParam(defaultValue = "파인더스") String nickname
+    ) {
+        SignupTokenPayload payload = new SignupTokenPayload(
+                provider,
+                providerId,
+                "mock_access_token",
+                name,
+                nickname,
+                "https://test-image.com",
+                email
+        );
+
+        String token = signupTokenProvider.createSignupToken(payload);
+
+        return ResponseEntity.ok(Map.of("signupToken", token));
     }
 }

--- a/src/main/java/com/finders/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/finders/api/global/config/SecurityConfig.java
@@ -65,7 +65,8 @@ public class SecurityConfig {
             // HM-010 인기 현상소 미리보기
             "/photo-labs/popular",
             // 개발용 토큰 발급
-            "/dev/login"
+            "/dev/login",
+            "/dev/signup-token"
     };
 
     @Bean

--- a/src/main/java/com/finders/api/infra/oauth/kakao/KakaoOAuthClient.java
+++ b/src/main/java/com/finders/api/infra/oauth/kakao/KakaoOAuthClient.java
@@ -39,18 +39,6 @@ public class KakaoOAuthClient implements OAuthClient {
 
     @Override
     public OAuthUserInfo getUserInfo(String accessToken) {
-        // 로컬 환경이고 특정 토큰일 때만 모킹 작동
-        if (isMockEnabled && ("string".equals(accessToken) || "test_token".equals(accessToken))) {
-            return OAuthUserInfo.builder()
-                    .provider(SocialProvider.KAKAO)
-                    .providerId("999999999") // DB에 없는 새로운 ID로 설정
-                    .name("테스트유저")
-                    .nickname("파인더스")
-                    .profileImage("https://test-image.com")
-                    .email("test@kakao.com")
-                    .build();
-        }
-
         try {
             KakaoUserMeResponse response = kakaoRestClient.get()
                     .uri("/v2/user/me")


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
<!-- 변경 사항을 간단히 설명해주세요 -->
로컬 개발 환경에서 OAuth 인증 과정 없이 즉시 테스트 유저로 로그인/회원가입을 진행할 수 있도록 SignupToken 발급 전용 개발 API를 추가했습니다.

## Changes
<!-- 변경된 내용을 목록으로 작성해주세요 -->
- /api/dev/signup-token 엔드포인트를 구현했습니다.
- 실제 카카오 서버와의 통신 없이 SignupTokenProvider를 통해 임의의 가입 토큰을 즉시 생성할 수 있는 기능을 제공합니다.


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [x] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [x] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->
Closes #325 

## Checklist
<!-- PR 제출 전 확인사항 -->
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다


## Screenshots (Optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->


## Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

