### PR TITLE
[FIX] Blue-Green 배포 스크립트 jq 파싱 및 env-file 오류 수정 (#101)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -102,7 +102,7 @@ jobs:
               echo '${{ secrets.ENV_DEV }}' | sudo tee .env.dev > /dev/null
 
               # ── Blue-Green 슬롯 감지 ──
-              ACTIVE_SLOT=\$(sudo docker compose -f docker-compose.infra.yml -f docker-compose.dev.yml ps --format json | jq -r '.[].Service' | grep -E 'dev-blue|dev-green' | head -1 || echo 'none')
+              ACTIVE_SLOT=\$(sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml ps --format json 2>/dev/null | jq -sr '.[].Service' 2>/dev/null | grep -E 'dev-blue|dev-green' | head -1 || echo 'none')
 
               if [[ \"\$ACTIVE_SLOT\" == 'dev-blue' ]]; then
                 GREEN_SLOT='green'
@@ -119,20 +119,20 @@ jobs:
               # ── 최초 배포: 베이스 인프라 시작 ──
               if [[ \"\$ACTIVE_SLOT\" == 'none' ]]; then
                 echo '최초 배포 감지 - 베이스 인프라 시작...'
-                sudo docker compose -f docker-compose.infra.yml -f docker-compose.dev.yml up -d traefik cloudflared redis-dev
+                sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml up -d traefik cloudflared redis-dev
                 sleep 10
               fi
 
               # ── 이미지 Pull ──
-              sudo docker compose -f docker-compose.infra.yml -f docker-compose.dev.yml pull
+              sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml pull
 
               # ── Green 슬롯 시작 ──
               echo \"Green 슬롯(dev-\$GREEN_SLOT) 시작...\"
-              sudo docker compose -f docker-compose.infra.yml -f docker-compose.dev.yml --profile \$GREEN_SLOT up -d
+              sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml --profile \$GREEN_SLOT up -d
 
               # ── Health Check (직접 컨테이너 실행) ──
               echo 'Health Check 시작...'
-              GREEN_CONTAINER=\$(sudo docker compose -f docker-compose.infra.yml -f docker-compose.dev.yml ps --format json | jq -r '.[] | select(.Service | contains(\"dev-'\$GREEN_SLOT'\")) | .Name')
+              GREEN_CONTAINER=\$(sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml ps --format json 2>/dev/null | jq -sr '.[] | select(.Service | contains(\"dev-'\$GREEN_SLOT'\")) | .Name')
 
               for i in {1..20}; do
                 if sudo docker exec \$GREEN_CONTAINER wget --spider -q http://localhost:8080/api/actuator/health; then
@@ -141,8 +141,8 @@ jobs:
                 fi
                 if [ \$i -eq 20 ]; then
                   echo '❌ Green Health Check 실패 - 롤백 진행'
-                  sudo docker compose -f docker-compose.infra.yml -f docker-compose.dev.yml --profile \$GREEN_SLOT stop
-                  sudo docker compose -f docker-compose.infra.yml -f docker-compose.dev.yml --profile \$GREEN_SLOT rm -f
+                  sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml --profile \$GREEN_SLOT stop
+                  sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml --profile \$GREEN_SLOT rm -f
                   exit 1
                 fi
                 echo \"대기 중... (\$i/20)\"
@@ -152,8 +152,8 @@ jobs:
               # ── Blue 슬롯 중지 및 제거 ──
               if [[ \"\$ACTIVE_SLOT\" != 'none' ]]; then
                 echo \"기존 슬롯(dev-\$BLUE_SLOT) 중지...\"
-                sudo docker compose -f docker-compose.infra.yml -f docker-compose.dev.yml --profile \$BLUE_SLOT stop
-                sudo docker compose -f docker-compose.infra.yml -f docker-compose.dev.yml --profile \$BLUE_SLOT rm -f
+                sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml --profile \$BLUE_SLOT stop
+                sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml --profile \$BLUE_SLOT rm -f
               fi
 
               # ── 정리 ──

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,7 +108,7 @@ jobs:
               echo '${{ secrets.ENV_PROD }}' | sudo tee .env.prod > /dev/null
 
               # ── 현재 활성 슬롯 감지 ──
-              ACTIVE_SLOT=\$(sudo docker compose -f docker-compose.infra.yml -f docker-compose.prod.yml ps --format json | jq -r '.[].Service' | grep -E 'prod-blue|prod-green' | head -1 || echo \"none\")
+              ACTIVE_SLOT=\$(sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml ps --format json 2>/dev/null | jq -sr '.[].Service' 2>/dev/null | grep -E 'prod-blue|prod-green' | head -1 || echo \"none\")
               if [[ \"\$ACTIVE_SLOT\" == \"prod-blue\" ]]; then
                 GREEN_SLOT=\"green\"
                 BLUE_SLOT=\"blue\"
@@ -121,20 +121,20 @@ jobs:
               # ── 최초 배포 시 베이스 인프라 시작 ──
               if [[ \"\$ACTIVE_SLOT\" == \"none\" ]]; then
                 echo \"🚀 최초 배포: 베이스 인프라 시작\"
-                sudo docker compose -f docker-compose.infra.yml up -d
+                sudo docker compose --env-file .env.prod -f docker-compose.infra.yml up -d
                 sleep 10
               fi
 
               # ── 새 이미지 Pull ──
-              sudo docker compose -f docker-compose.infra.yml -f docker-compose.prod.yml pull
+              sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml pull
 
               # ── Green 슬롯 시작 ──
               echo \"🟢 Green 슬롯(\$GREEN_SLOT) 시작\"
-              sudo docker compose -f docker-compose.infra.yml -f docker-compose.prod.yml --profile \$GREEN_SLOT up -d
+              sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml --profile \$GREEN_SLOT up -d
 
               # ── Direct Health Check (Traefik 우회) ──
               echo \"💓 Health Check 시작 (direct container exec)...\"
-              GREEN_CONTAINER=\$(sudo docker compose -f docker-compose.infra.yml -f docker-compose.prod.yml ps --format json | jq -r '.[] | select(.Service | contains(\"prod-'\$GREEN_SLOT'\")) | .Name')
+              GREEN_CONTAINER=\$(sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml ps --format json 2>/dev/null | jq -sr '.[] | select(.Service | contains(\"prod-'\$GREEN_SLOT'\")) | .Name')
               for i in {1..20}; do
                 if sudo docker exec \$GREEN_CONTAINER wget --spider -q http://localhost:8080/api/actuator/health; then
                   echo \"✅ Green slot healthy\"
@@ -142,8 +142,8 @@ jobs:
                 fi
                 if [ \$i -eq 20 ]; then
                   echo \"❌ Green health check failed\"
-                  sudo docker compose -f docker-compose.infra.yml -f docker-compose.prod.yml --profile \$GREEN_SLOT stop
-                  sudo docker compose -f docker-compose.infra.yml -f docker-compose.prod.yml --profile \$GREEN_SLOT rm -f
+                  sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml --profile \$GREEN_SLOT stop
+                  sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml --profile \$GREEN_SLOT rm -f
                   exit 1
                 fi
                 echo \"⏳ 대기 중... (\$i/20)\"
@@ -152,8 +152,8 @@ jobs:
 
               # ── Blue 슬롯 정리 ──
               echo \"🔵 Blue 슬롯(\$BLUE_SLOT) 정리\"
-              sudo docker compose -f docker-compose.infra.yml -f docker-compose.prod.yml --profile \$BLUE_SLOT stop
-              sudo docker compose -f docker-compose.infra.yml -f docker-compose.prod.yml --profile \$BLUE_SLOT rm -f
+              sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml --profile \$BLUE_SLOT stop
+              sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml --profile \$BLUE_SLOT rm -f
 
               # ── 미사용 이미지 정리 ──
               sudo docker image prune -f


### PR DESCRIPTION
## Summary

Blue-Green 배포 워크플로우에서 `docker compose ps --format json`의 NDJSON 출력을 JSON 배열로 잘못 파싱하던 버그를 수정합니다.

## Changes

- `jq -r '.[].Service'` → `jq -sr '.[].Service'` (NDJSON을 배열로 slurp 후 파싱)
- 모든 `docker compose` 명령에 `--env-file` 플래그 추가 (`TUNNEL_TOKEN` 미설정 경고 해소)
- `ps`, `jq` 명령에 `2>/dev/null` 추가 (최초 배포 시 빈 출력 안전 처리)

### 원인 분석

| 증상 | 원인 |
|------|------|
| `jq: Cannot index string with "Service"` | `docker compose ps --format json`은 JSON 배열이 아닌 NDJSON(줄당 1개 JSON 객체) 출력. `jq -r '.[].Service'`가 객체를 배열로 착각 |
| `No such container: wget` | 위 jq 오류로 `GREEN_CONTAINER` 변수가 빈 문자열 → `docker exec wget`으로 실행됨 |
| `TUNNEL_TOKEN variable is not set` | `docker-compose.infra.yml`의 `${TUNNEL_TOKEN}`을 해석하려면 `--env-file`이 필요하지만 누락 |

## Type of Change

- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)

## Related Issues

Relates to #101

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다

## Additional Notes

`deploy-dev.yml`과 `deploy.yml` 양쪽 모두 동일한 패턴으로 수정했습니다. 머지 후 develop push로 dev 배포가 자동 트리거됩니다.