### PR TITLE
[FIX] Blue-Green 배포: Redis 환경변수 누락 및 health check/rollback 개선 (#101)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -89,20 +89,18 @@ jobs:
             --tunnel-through-iap \
             --quiet \
             --command="
-              # 홈에 있는 파일을 sudo로 목적지 이동
               sudo mv ~/docker-compose.infra.yml /projects/Spring/docker-compose.infra.yml
               sudo mv ~/docker-compose.dev.yml /projects/Spring/docker-compose.dev.yml
 
               cd /projects/Spring
+              DC='sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml'
 
-              # Docker 네트워크 생성 (없을 경우)
               sudo docker network create finders-network || true
-
-              # 환경변수 파일 생성
               echo '${{ secrets.ENV_DEV }}' | sudo tee .env.dev > /dev/null
 
               # ── Blue-Green 슬롯 감지 ──
-              ACTIVE_SLOT=\$(sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml ps --format json 2>/dev/null | jq -sr '.[].Service' 2>/dev/null | grep -E 'dev-blue|dev-green' | head -1 || echo 'none')
+              ACTIVE_SLOT=\$(\$DC ps --format json 2>/dev/null | jq -sr '.[].Service' 2>/dev/null | grep -E 'dev-blue|dev-green' | head -1)
+              ACTIVE_SLOT=\${ACTIVE_SLOT:-none}
 
               if [[ \"\$ACTIVE_SLOT\" == 'dev-blue' ]]; then
                 GREEN_SLOT='green'
@@ -112,51 +110,59 @@ jobs:
                 BLUE_SLOT='green'
               fi
 
-              echo \"현재 활성 슬롯: \$ACTIVE_SLOT\"
-              echo \"새 슬롯(Green): dev-\$GREEN_SLOT\"
-              echo \"기존 슬롯(Blue): dev-\$BLUE_SLOT\"
+              echo \"현재: \$ACTIVE_SLOT / 새 슬롯: dev-\$GREEN_SLOT / 기존: dev-\$BLUE_SLOT\"
 
               # ── 최초 배포: 베이스 인프라 시작 ──
               if [[ \"\$ACTIVE_SLOT\" == 'none' ]]; then
                 echo '최초 배포 감지 - 베이스 인프라 시작...'
-                sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml up -d traefik cloudflared redis-dev
+                \$DC up -d traefik cloudflared redis-dev
                 sleep 10
               fi
 
-              # ── 이미지 Pull ──
-              sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml pull
-
-              # ── Green 슬롯 시작 ──
+              \$DC pull
               echo \"Green 슬롯(dev-\$GREEN_SLOT) 시작...\"
-              sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml --profile \$GREEN_SLOT up -d
+              \$DC --profile \$GREEN_SLOT up -d
 
-              # ── Health Check (직접 컨테이너 실행) ──
-              echo 'Health Check 시작...'
-              GREEN_CONTAINER=\$(sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml ps --format json 2>/dev/null | jq -sr '.[] | select(.Service | contains(\"dev-'\$GREEN_SLOT'\")) | .Name')
+              # ── Health Check (Docker 네이티브 health status 사용) ──
+              GREEN_CONTAINER=\$(\$DC ps --format json 2>/dev/null | jq -sr \".[] | select(.Service == \\\"dev-\$GREEN_SLOT\\\") | .Name\")
+              echo \"Health Check 시작... (container: \$GREEN_CONTAINER)\"
 
-              for i in {1..20}; do
-                if sudo docker exec \$GREEN_CONTAINER wget --spider -q http://localhost:8080/api/actuator/health; then
-                  echo '✅ Green 슬롯 정상 확인!'
+              for i in {1..36}; do
+                STATUS=\$(sudo docker inspect --format='{{.State.Health.Status}}' \"\$GREEN_CONTAINER\" 2>/dev/null || echo 'not_found')
+
+                if [[ \"\$STATUS\" == 'healthy' ]]; then
+                  echo \"✅ Green 슬롯 정상 확인! (\${i}번째 체크)\"
                   break
                 fi
-                if [ \$i -eq 20 ]; then
-                  echo '❌ Green Health Check 실패 - 롤백 진행'
-                  sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml --profile \$GREEN_SLOT stop
-                  sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml --profile \$GREEN_SLOT rm -f
+
+                if [[ \"\$STATUS\" == 'unhealthy' ]]; then
+                  echo '❌ Container unhealthy - 롤백 진행'
+                  sudo docker inspect --format='{{range .State.Health.Log}}{{.Output}}{{end}}' \"\$GREEN_CONTAINER\" 2>/dev/null || true
+                  sudo docker logs --tail 80 \"\$GREEN_CONTAINER\" 2>/dev/null || true
+                  sudo docker stop \"\$GREEN_CONTAINER\" 2>/dev/null && sudo docker rm -f \"\$GREEN_CONTAINER\" 2>/dev/null
                   exit 1
                 fi
-                echo \"대기 중... (\$i/20)\"
+
+                if [ \$i -eq 36 ]; then
+                  echo '❌ Health Check 타임아웃 (180s) - 롤백 진행'
+                  sudo docker logs --tail 80 \"\$GREEN_CONTAINER\" 2>/dev/null || true
+                  sudo docker stop \"\$GREEN_CONTAINER\" 2>/dev/null && sudo docker rm -f \"\$GREEN_CONTAINER\" 2>/dev/null
+                  exit 1
+                fi
+
+                echo \"대기 중... (\$i/36) status=\$STATUS\"
                 sleep 5
               done
 
-              # ── Blue 슬롯 중지 및 제거 ──
+              # ── Blue 슬롯 중지 (인프라는 유지) ──
               if [[ \"\$ACTIVE_SLOT\" != 'none' ]]; then
-                echo \"기존 슬롯(dev-\$BLUE_SLOT) 중지...\"
-                sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml --profile \$BLUE_SLOT stop
-                sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml --profile \$BLUE_SLOT rm -f
+                OLD_CONTAINER=\$(\$DC ps --format json 2>/dev/null | jq -sr \".[] | select(.Service == \\\"dev-\$BLUE_SLOT\\\") | .Name\")
+                if [[ -n \"\$OLD_CONTAINER\" ]]; then
+                  echo \"기존 슬롯(\$OLD_CONTAINER) 중지...\"
+                  sudo docker stop \"\$OLD_CONTAINER\" 2>/dev/null && sudo docker rm -f \"\$OLD_CONTAINER\" 2>/dev/null
+                fi
               fi
 
-              # ── 정리 ──
               sudo docker image prune -f
               echo '✅ Dev Blue-Green 배포 완료!'
             "

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,67 +95,79 @@ jobs:
             --tunnel-through-iap \
             --quiet \
             --command="
-              # 파일을 목적지로 이동
               sudo mv ~/docker-compose.infra.yml /projects/Spring/docker-compose.infra.yml
               sudo mv ~/docker-compose.prod.yml /projects/Spring/docker-compose.prod.yml
 
               cd /projects/Spring
+              DC='sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml'
 
-              # 외부 네트워크가 없을 경우 생성
               sudo docker network create finders-network || true
-
-              # 환경변수 파일 생성
               echo '${{ secrets.ENV_PROD }}' | sudo tee .env.prod > /dev/null
 
               # ── 현재 활성 슬롯 감지 ──
-              ACTIVE_SLOT=\$(sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml ps --format json 2>/dev/null | jq -sr '.[].Service' 2>/dev/null | grep -E 'prod-blue|prod-green' | head -1 || echo \"none\")
-              if [[ \"\$ACTIVE_SLOT\" == \"prod-blue\" ]]; then
-                GREEN_SLOT=\"green\"
-                BLUE_SLOT=\"blue\"
+              ACTIVE_SLOT=\$(\$DC ps --format json 2>/dev/null | jq -sr '.[].Service' 2>/dev/null | grep -E 'prod-blue|prod-green' | head -1)
+              ACTIVE_SLOT=\${ACTIVE_SLOT:-none}
+
+              if [[ \"\$ACTIVE_SLOT\" == 'prod-blue' ]]; then
+                GREEN_SLOT='green'
+                BLUE_SLOT='blue'
               else
-                GREEN_SLOT=\"blue\"
-                BLUE_SLOT=\"green\"
+                GREEN_SLOT='blue'
+                BLUE_SLOT='green'
               fi
-              echo \"🔍 Active: \$ACTIVE_SLOT → New: \$GREEN_SLOT, Old: \$BLUE_SLOT\"
+              echo \"현재: \$ACTIVE_SLOT / 새 슬롯: prod-\$GREEN_SLOT / 기존: prod-\$BLUE_SLOT\"
 
               # ── 최초 배포 시 베이스 인프라 시작 ──
-              if [[ \"\$ACTIVE_SLOT\" == \"none\" ]]; then
-                echo \"🚀 최초 배포: 베이스 인프라 시작\"
-                sudo docker compose --env-file .env.prod -f docker-compose.infra.yml up -d
+              if [[ \"\$ACTIVE_SLOT\" == 'none' ]]; then
+                echo '최초 배포: 베이스 인프라 시작'
+                \$DC up -d traefik cloudflared
                 sleep 10
               fi
 
-              # ── 새 이미지 Pull ──
-              sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml pull
+              \$DC pull
+              echo \"Green 슬롯(prod-\$GREEN_SLOT) 시작\"
+              \$DC --profile \$GREEN_SLOT up -d
 
-              # ── Green 슬롯 시작 ──
-              echo \"🟢 Green 슬롯(\$GREEN_SLOT) 시작\"
-              sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml --profile \$GREEN_SLOT up -d
+              # ── Health Check (Docker 네이티브 health status) ──
+              GREEN_CONTAINER=\$(\$DC ps --format json 2>/dev/null | jq -sr \".[] | select(.Service == \\\"prod-\$GREEN_SLOT\\\") | .Name\")
+              echo \"Health Check 시작... (container: \$GREEN_CONTAINER)\"
 
-              # ── Direct Health Check (Traefik 우회) ──
-              echo \"💓 Health Check 시작 (direct container exec)...\"
-              GREEN_CONTAINER=\$(sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml ps --format json 2>/dev/null | jq -sr '.[] | select(.Service | contains(\"prod-'\$GREEN_SLOT'\")) | .Name')
-              for i in {1..20}; do
-                if sudo docker exec \$GREEN_CONTAINER wget --spider -q http://localhost:8080/api/actuator/health; then
-                  echo \"✅ Green slot healthy\"
+              for i in {1..36}; do
+                STATUS=\$(sudo docker inspect --format='{{.State.Health.Status}}' \"\$GREEN_CONTAINER\" 2>/dev/null || echo 'not_found')
+
+                if [[ \"\$STATUS\" == 'healthy' ]]; then
+                  echo \"✅ Green 슬롯 정상 확인! (\${i}번째 체크)\"
                   break
                 fi
-                if [ \$i -eq 20 ]; then
-                  echo \"❌ Green health check failed\"
-                  sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml --profile \$GREEN_SLOT stop
-                  sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml --profile \$GREEN_SLOT rm -f
+
+                if [[ \"\$STATUS\" == 'unhealthy' ]]; then
+                  echo '❌ Container unhealthy - 롤백 진행'
+                  sudo docker inspect --format='{{range .State.Health.Log}}{{.Output}}{{end}}' \"\$GREEN_CONTAINER\" 2>/dev/null || true
+                  sudo docker logs --tail 80 \"\$GREEN_CONTAINER\" 2>/dev/null || true
+                  sudo docker stop \"\$GREEN_CONTAINER\" 2>/dev/null && sudo docker rm -f \"\$GREEN_CONTAINER\" 2>/dev/null
                   exit 1
                 fi
-                echo \"⏳ 대기 중... (\$i/20)\"
+
+                if [ \$i -eq 36 ]; then
+                  echo '❌ Health Check 타임아웃 (180s) - 롤백 진행'
+                  sudo docker logs --tail 80 \"\$GREEN_CONTAINER\" 2>/dev/null || true
+                  sudo docker stop \"\$GREEN_CONTAINER\" 2>/dev/null && sudo docker rm -f \"\$GREEN_CONTAINER\" 2>/dev/null
+                  exit 1
+                fi
+
+                echo \"대기 중... (\$i/36) status=\$STATUS\"
                 sleep 5
               done
 
-              # ── Blue 슬롯 정리 ──
-              echo \"🔵 Blue 슬롯(\$BLUE_SLOT) 정리\"
-              sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml --profile \$BLUE_SLOT stop
-              sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml --profile \$BLUE_SLOT rm -f
+              # ── Blue 슬롯 중지 (인프라는 유지) ──
+              if [[ \"\$ACTIVE_SLOT\" != 'none' ]]; then
+                OLD_CONTAINER=\$(\$DC ps --format json 2>/dev/null | jq -sr \".[] | select(.Service == \\\"prod-\$BLUE_SLOT\\\") | .Name\")
+                if [[ -n \"\$OLD_CONTAINER\" ]]; then
+                  echo \"기존 슬롯(\$OLD_CONTAINER) 중지...\"
+                  sudo docker stop \"\$OLD_CONTAINER\" 2>/dev/null && sudo docker rm -f \"\$OLD_CONTAINER\" 2>/dev/null
+                fi
+              fi
 
-              # ── 미사용 이미지 정리 ──
               sudo docker image prune -f
-              echo \"✅ Blue-Green 배포 완료!\"
+              echo '✅ Prod Blue-Green 배포 완료!'
             "

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -21,13 +21,14 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: dev
       TZ: Asia/Seoul
-      SPRING_DATA_REDIS_HOST: finders-redis-dev
-      SPRING_DATA_REDIS_PORT: 6379
+      REDIS_HOST: finders-redis-dev
+      REDIS_PORT: 6379
+      REDIS_PASSWORD: ""
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/api/actuator/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
+      interval: 20s
+      timeout: 5s
+      retries: 5
       start_period: 60s
     labels:
       - "traefik.enable=true"
@@ -54,13 +55,14 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: dev
       TZ: Asia/Seoul
-      SPRING_DATA_REDIS_HOST: finders-redis-dev
-      SPRING_DATA_REDIS_PORT: 6379
+      REDIS_HOST: finders-redis-dev
+      REDIS_PORT: 6379
+      REDIS_PASSWORD: ""
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/api/actuator/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
+      interval: 20s
+      timeout: 5s
+      retries: 5
       start_period: 60s
     labels:
       - "traefik.enable=true"


### PR DESCRIPTION
## Summary

Blue-Green 배포 health check가 20/20 실패한 근본 원인을 수정합니다.

## Changes

### 핵심 수정: Redis 환경변수 누락 (`docker-compose.dev.yml`)
- `SPRING_DATA_REDIS_HOST` → `REDIS_HOST` (application.yml의 `${REDIS_HOST:localhost}`와 일치)
- `REDIS_PASSWORD: ""` 추가 (application.yml의 `${REDIS_PASSWORD}` placeholder 해소)
- Docker Redis는 비밀번호가 없으므로 빈 문자열로 설정

### Health Check 방식 변경 (`deploy-dev.yml`, `deploy.yml`)
- `docker exec wget` → `docker inspect --format='{{.State.Health.Status}}'`
- Docker 네이티브 health status를 폴링하여 wget/curl 의존성 제거
- `unhealthy` 즉시 감지, `healthy` 확인 시 즉시 통과
- 타임아웃 100s → 180s (start_period 60s + 여유)

### 롤백 안전성 (`deploy-dev.yml`, `deploy.yml`)
- `docker compose --profile stop` → `docker stop/rm` (특정 컨테이너만)
- 기존: `--profile blue stop`이 Traefik, cloudflared, Redis까지 전부 중지
- 수정: 슬롯 컨테이너만 중지, 인프라는 유지

### 디버깅 (`deploy-dev.yml`, `deploy.yml`)
- 실패 시 `docker logs --tail 80` 출력 (Spring Boot 에러 확인 가능)
- `docker inspect` health log 출력
- ACTIVE_SLOT 빈 문자열 버그 수정 (`${ACTIVE_SLOT:-none}`)

## Type of Change

- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)

## Related Issues

Relates to #101

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다