### PR TITLE
[FIX] Redis SSL 강제 비활성화 — dev 배포 rediss:// 연결 오류 (#101)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -24,6 +24,7 @@ services:
       REDIS_HOST: finders-redis-dev
       REDIS_PORT: 6379
       REDIS_PASSWORD: ""
+      SPRING_DATA_REDIS_SSL_ENABLED: "false"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/api/actuator/health"]
       interval: 20s
@@ -58,6 +59,7 @@ services:
       REDIS_HOST: finders-redis-dev
       REDIS_PORT: 6379
       REDIS_PASSWORD: ""
+      SPRING_DATA_REDIS_SSL_ENABLED: "false"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/api/actuator/health"]
       interval: 20s


### PR DESCRIPTION
## Summary

Dev 환경에서 Docker Redis에 SSL(`rediss://`)로 연결 시도하여 health check 실패하는 문제를 수정합니다.

## Changes

- `docker-compose.dev.yml`: `SPRING_DATA_REDIS_SSL_ENABLED: "false"` 환경변수 추가 (blue/green 모두)

### 원인

`application-dev.yml`에서 `ssl.enabled: false`로 오버라이드했지만, 실제 런타임에서는 `rediss://` (SSL)로 연결을 시도했습니다. `.env.dev`의 환경변수가 profile 설정보다 높은 우선순위를 가지기 때문에, compose `environment:`에서 명시적으로 `SPRING_DATA_REDIS_SSL_ENABLED=false`를 설정하여 확실하게 비활성화합니다.

## Type of Change

- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)

## Related Issues

Relates to #101

## Checklist

- [x] 코드 컨벤션을 준수했습니다
- [x] 로컬에서 빌드가 정상적으로 완료됩니다