### PR TITLE
[FIX] prod Redis SSL, 로깅 분리, compose 프로젝트 네임 (#101)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -93,7 +93,7 @@ jobs:
               sudo mv ~/docker-compose.dev.yml /projects/Spring/docker-compose.dev.yml
 
               cd /projects/Spring
-              DC='sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml'
+              DC='sudo docker compose -p finders-dev --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml'
 
               sudo docker network create finders-network || true
               echo '${{ secrets.ENV_DEV }}' | sudo tee .env.dev > /dev/null

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -99,7 +99,7 @@ jobs:
               sudo mv ~/docker-compose.prod.yml /projects/Spring/docker-compose.prod.yml
 
               cd /projects/Spring
-              DC='sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml'
+              DC='sudo docker compose -p finders-prod --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml'
 
               sudo docker network create finders-network || true
               echo '${{ secrets.ENV_PROD }}' | sudo tee .env.prod > /dev/null

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,6 +9,20 @@
 # ========================================
 
 services:
+  # ── Redis (dev 전용) ──
+  redis-dev:
+    image: redis:latest
+    container_name: finders-redis-dev
+    restart: unless-stopped
+    command: redis-server --save 60 1 --loglevel warning
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - finders-network
+
   # ── Dev Blue ──
   dev-blue:
     image: findersofficial/finders-api:dev

--- a/docker-compose.infra.yml
+++ b/docker-compose.infra.yml
@@ -50,20 +50,6 @@ services:
     networks:
       - finders-network
 
-  # ── Redis (dev) ──
-  redis-dev:
-    image: redis:latest
-    container_name: finders-redis-dev
-    restart: unless-stopped
-    command: redis-server --save 60 1 --loglevel warning
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    networks:
-      - finders-network
-
 networks:
   finders-network:
     external: true

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,6 +24,7 @@ services:
       - .env.prod
     environment:
       SPRING_PROFILES_ACTIVE: prod
+      SPRING_DATA_REDIS_SSL_ENABLED: "true"
       TZ: Asia/Seoul
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/api/actuator/health"]
@@ -54,6 +55,7 @@ services:
       - .env.prod
     environment:
       SPRING_PROFILES_ACTIVE: prod
+      SPRING_DATA_REDIS_SSL_ENABLED: "true"
       TZ: Asia/Seoul
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/api/actuator/health"]

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -38,6 +38,8 @@ logging:
     com.finders: DEBUG
     org.springframework.web: INFO
     org.hibernate.SQL: DEBUG
+    org.springframework.data.redis: DEBUG
+    io.lettuce.core: DEBUG
 
 # ========================================
 # Actuator (개발용 노출)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -25,6 +25,8 @@ logging:
   level:
     org.hibernate.SQL: DEBUG
     org.hibernate.orm.jdbc.bind: TRACE
+    org.springframework.data.redis: DEBUG
+    io.lettuce.core: DEBUG
 
 auth:
   mock:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -185,8 +185,6 @@ logging:
   level:
     root: INFO
     com.finders: DEBUG
-    org.springframework.data.redis: DEBUG
-    io.lettuce.core: DEBUG
 
 # ========================================
 # CORS 설정


### PR DESCRIPTION
## Summary

Prod Redis SSL 명시, Redis/Lettuce DEBUG 로깅 분리, compose 프로젝트 네임 추가, redis-dev 서비스 위치 분리

## Changes

- `docker-compose.prod.yml`: `SPRING_DATA_REDIS_SSL_ENABLED: "true"` 추가 (Upstash TLS 연결 안전장치, blue + green)
- `docker-compose.infra.yml`: `redis-dev` 서비스 제거 (prod에서 불필요한 Redis 컨테이너 방지)
- `docker-compose.dev.yml`: `redis-dev` 서비스 추가
- `application.yml`: Redis/Lettuce DEBUG 로그 레벨 제거 (prod 로그 노이즈 제거)
- `application-dev.yml`: Redis/Lettuce DEBUG 로그 레벨 추가
- `application-local.yml`: Redis/Lettuce DEBUG 로그 레벨 추가
- `deploy.yml`: `-p finders-prod` 추가 (orphan 컨테이너 경고 해결)
- `deploy-dev.yml`: `-p finders-dev` 추가

## Type of Change

- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues

Relates to #101

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다