### PR TITLE
[FIX] -p 프로젝트 네임 제거 — infra 컨테이너 충돌 해결 (#101)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -94,7 +94,7 @@ jobs:
               sudo mv ~/docker-compose.dev.yml /projects/Spring/docker-compose.dev.yml
 
               cd /projects/Spring
-              DC='sudo docker compose -p finders-dev --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml'
+              DC='sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml'
 
               sudo docker network create finders-network || true
               echo '${{ secrets.ENV_DEV }}' | sudo tee .env.dev > /dev/null

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,7 +100,7 @@ jobs:
               sudo mv ~/docker-compose.prod.yml /projects/Spring/docker-compose.prod.yml
 
               cd /projects/Spring
-              DC='sudo docker compose -p finders-prod --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml'
+              DC='sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml'
 
               sudo docker network create finders-network || true
               echo '${{ secrets.ENV_PROD }}' | sudo tee .env.prod > /dev/null


### PR DESCRIPTION
## Summary

dev와 prod가 같은 GCE 서버에서 공유 infra(finders-traefik, finders-tunnel)를 사용하므로, `-p` 프로젝트 네임 분리 시 `container_name` 충돌이 발생하는 문제 수정

## Changes

- `deploy.yml`: `-p finders-prod` 제거
- `deploy-dev.yml`: `-p finders-dev` 제거

## Type of Change

- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues

Relates to #101

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes

orphan 컨테이너 경고는 cosmetic(무해)이므로 수용합니다. `--remove-orphans` 플래그는 의도적으로 사용하지 않습니다 (다른 compose 파일의 컨테이너를 삭제할 위험).