### PR TITLE
[FEAT] Redis 장애 대응 전략 수립 및 리프레시 토큰 하이브리드 저장 방식 구현 (#362)

### DIFF
--- a/src/main/java/com/finders/api/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/finders/api/global/exception/GlobalExceptionHandler.java
@@ -9,7 +9,7 @@ import jakarta.validation.ConstraintViolationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.hibernate.QueryTimeoutException;
+import org.springframework.dao.QueryTimeoutException;
 import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/finders/api/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/finders/api/global/exception/GlobalExceptionHandler.java
@@ -132,23 +132,11 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(ErrorCode.NOT_FOUND));
     }
 
-    // Redis 연결 장애 및 타임아웃 처리 (Redis가 필수인 로직에서 장애인 경우)
     @ExceptionHandler({RedisConnectionFailureException.class, QueryTimeoutException.class})
-    public ResponseEntity<ApiResponse<Void>> handleRedisException(
-        Exception e,
-        HttpServletRequest request
-    ) {
-        log.error("[RedisException] {} - {}", request.getRequestURI(), e.getMessage(), e);
-
-        try {
-            discordWebhookService.sendErrorNotification(e, request.getMethod(), request.getRequestURI());
-        } catch (Exception ignored) {
-            log.warn("[DiscordWebhook] Failed to send notification", ignored);
-        }
-
+    public ResponseEntity<ApiResponse<Void>> handleRedisException(Exception e) {
         return ResponseEntity
             .status(HttpStatus.SERVICE_UNAVAILABLE.value())
-            .body(ApiResponse.error(ErrorCode.AUTH_SERVER_ERROR));
+            .body(ApiResponse.error(ErrorCode.EXTERNAL_API_ERROR));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/finders/api/global/response/ErrorCode.java
+++ b/src/main/java/com/finders/api/global/response/ErrorCode.java
@@ -63,6 +63,7 @@ public enum ErrorCode implements BaseCode {
     AUTH_PHONE_CODE_EXPIRED(HttpStatus.BAD_REQUEST, "AUTH_421", "인증번호가 만료되었거나 존재하지 않습니다."),
     AUTH_PHONE_MAX_ATTEMPTS_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "AUTH_422", "인증 시도 횟수를 초과했습니다."),
     AUTH_PHONE_ALREADY_VERIFIED(HttpStatus.CONFLICT, "AUTH_423", "이미 인증이 완료된 요청입니다."),
+    AUTH_SERVER_ERROR(HttpStatus.SERVICE_UNAVAILABLE, "AUTH_503", "현재 인증 서비스 이용이 원활하지 않습니다. 잠시 후 다시 시도해주세요."),
 
     // 로그인 실패
     AUTH_LOGIN_FAILED(HttpStatus.BAD_REQUEST, "AUTH_401", "이메일 또는 비밀번호가 일치하지 않습니다."),

--- a/src/main/java/com/finders/api/global/security/RefreshTokenHasher.java
+++ b/src/main/java/com/finders/api/global/security/RefreshTokenHasher.java
@@ -1,5 +1,7 @@
 package com.finders.api.global.security;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.time.Duration;
 
 import com.finders.api.domain.member.entity.Member;
@@ -63,7 +65,10 @@ public class RefreshTokenHasher {
         }
 
         if (savedToken != null) {
-            return savedToken.equals(inputHashed);
+            return MessageDigest.isEqual(
+                savedToken.getBytes(StandardCharsets.UTF_8),
+                inputHashed.getBytes(StandardCharsets.UTF_8)
+            );
         }
 
         if (encodedHash == null) return false;


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
<!-- 변경 사항을 간단히 설명해주세요 -->
외부 서비스인 Redis(Upstash) 장애 시에도 인증 시스템의 안정성을 보장하기 위해 데이터 성격별 차별화된 대응 전략을 수립하고 이를 구현했습니다.

- 휴대폰 인증: 원본 데이터 부재 시 즉시 실패(Fail-Fast) 처리 및 유저 안내.
- 리프레시 토큰: Redis(캐시)와 DB(영속성)를 모두 활용하는 하이브리드(Fallback) 전략 적용.

## Changes
<!-- 변경된 내용을 목록으로 작성해주세요 -->
- Redis 장애 대응 및 가용성 확보
  - 도메인별 차별화 전략 적용:
    - 휴대폰 인증: Redis가 유일한 저장소이므로 장애 시 즉시 실패(AUTH_SERVER_ERROR, 503) 처리하여 데이터 부정합 방지 (Fail-Fast).
    - 리프레시 토큰: Redis(L1 캐시) 조회 실패 시 DB(L2 영속성)를 참조하는 하이브리드 검증 로직 구현 (Fallback).

  - 전역 예외 처리 연동:
    - RedisConnectionFailureException 등 인프라 장애 발생 시 유저에게 명확한 점검 가이드를 제공.

- 인증 에러 코드 추가 (ErrorCode):
  - AUTH_SERVER_ERROR(503)를 추가하여 인증 서버 점검 시 유저에게 명확한 가이드를 제공.

- 토큰 해싱 및 저장 로직 고도화 (RefreshTokenHasher):
  - 직렬화 안정성 확보:
    - GenericJackson2JsonRedisSerializer 사용 시 발생하는 문자열 역직렬화 오류(타입 정보 포함 및 따옴표 이슈)를 해결하기 위해 StringRedisTemplate으로 교체.
  
  - 타이밍 공격(Timing Attack) 방어:
    - 토큰 비교 시 MessageDigest.isEqual()(상수 시간 비교)을 도입하여 응답 시간 차이를 이용한 토큰 유추 공격을 원천 차단.

  - 이중 해싱 저장 전략:
    - Redis: 성능과 최소한의 보안을 위해 SHA-256 해시 저장.
    - DB: 영속성 보안을 위해 BCrypt 암호화 저장.

- 인증 서비스 리팩토링 (AuthCommandServiceImpl):
  - reissueToken: 새로운 토큰 발급 시 기존 토큰이 아닌 신규 토큰을 저장하도록 버그 수정.
  - 회원가입 및 로그인 시 하이브리드 저장 로직을 적용하여 DB 보안 해시와 Redis 캐시 동기화.


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [x] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [x] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->
Closes #362 

## Checklist
<!-- PR 제출 전 확인사항 -->
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다


## Screenshots (Optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->


## Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
- Fail-Fast 전략: 휴대폰 인증번호는 Redis가 유일한 저장소이므로, 장애 시 억지로 DB를 활용하기보다 즉시 에러를 반환하여 유저가 재시도할 수 있도록 유도하는 것이 데이터 정합성 측면에서 유리하다고 판단했습니다.
- Hybrid 전략: Refresh Token은 유저 경험(로그인 유지)과 직결되므로, 속도가 빠른 Redis를 주 저장소로 쓰되 장애 시 DB의 해시값을 확인하는 방어 로직을 구축했습니다.
- StringRedisTemplate 도입 배경: 일반적인 Object 직렬화기를 문자열(토큰 해시)에 적용할 경우 JSON 메타데이터가 포함되어 equals 비교가 실패하는 지점을 발견하여, 순수 문자열 전용 템플릿으로 분리했습니다.
- 상수 시간 비교(Constant-time comparison): String.equals()의 Short-circuit 특성을 이용한 타이밍 공격을 방지하기 위해 MessageDigest.isEqual을 적용하여 보안 수준을 강화했습니다.
