### PR TITLE
[FIX] Auto Release 버전 추출 오류 수정 (#373)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -25,13 +25,16 @@ jobs:
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "Last tag: $LAST_TAG"
 
-          FIRST_LINE=$(echo "$COMMIT_MSG" | head -1)
-          echo "Commit subject: $FIRST_LINE"
+          echo "Commit message:"
+          echo "$COMMIT_MSG"
 
-          # [RELEASE] v0.8.0 배포 또는 Merge pull request 제목에서 버전 추출
-          if [[ "$FIRST_LINE" =~ v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+          # 전체 커밋 메시지에서 버전 추출
+          # GitHub merge commit 구조:
+          #   Line 1: "Merge pull request #N from org/branch"
+          #   Line 3: PR 제목 (예: "[RELEASE] v0.9.2 배포")
+          if [[ "$COMMIT_MSG" =~ v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
             VERSION="v${BASH_REMATCH[1]}"
-            echo "Version from commit: $VERSION"
+            echo "Version from commit message: $VERSION"
           else
             # 버전 없으면 PATCH 자동 증가
             IFS='.' read -ra PARTS <<< "${LAST_TAG//v/}"


### PR DESCRIPTION
## Summary
Auto Release 워크플로우가 merge commit 첫 줄만 확인하여 PR 제목의 버전을 인식하지 못하는 버그 수정

## Changes
- `auto-release.yml`: `head -1`(첫 줄만) 대신 전체 `COMMIT_MSG`에서 버전 regex 매칭하도록 변경

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)

## Related Issues
Closes #373

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다