### PR TITLE
[DOCS] .env.example 환경변수 템플릿 최신화 (#375)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,15 +4,17 @@
 #
 # 사용법:
 #   로컬 개발: cp .env.example .env
-#   배포 서버: cp .env.example .env.prod (또는 GitHub Secrets 사용)
+#   개발 서버: cp .env.example .env.dev
+#   운영 서버: cp .env.example .env.prod
 #
 # ========================================
 
 # ========================================
 # Spring Profile
 # ========================================
-# local: 로컬 개발 (Docker MySQL)
-# prod: 배포 서버 (GCP Cloud SQL)
+# local: 로컬 개발 (Docker MySQL + Docker Redis)
+# dev: 개발 서버 (GCP Cloud SQL + Docker Redis)
+# prod: 운영 서버 (GCP Cloud SQL + Upstash Redis)
 SPRING_PROFILES_ACTIVE=local
 
 # ========================================
@@ -22,10 +24,19 @@ SPRING_PROFILES_ACTIVE=local
 #
 # [로컬] Docker MySQL (기본값 - 설정 안해도 됨)
 # [배포] GCP Cloud SQL - 아래 값 변경
-# ========================================
 SPRING_DATASOURCE_URL=jdbc:mysql://localhost:3306/finders?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
 SPRING_DATASOURCE_USERNAME=finders
 SPRING_DATASOURCE_PASSWORD=finders123
+
+# ========================================
+# Redis (캐싱)
+# ========================================
+# [로컬] Docker Redis (docker-compose.yml로 자동 실행)
+# [dev] Docker Redis (docker-compose.dev.yml에 포함)
+# [prod] Upstash Redis (SSL 필수)
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=
 
 # ========================================
 # JWT
@@ -39,6 +50,7 @@ JWT_SECRET=your-jwt-secret-key-must-be-at-least-256-bits-long-for-hs256
 # 카카오 로그인 + 주소→좌표 변환 (Kakao Local API)
 KAKAO_CLIENT_ID=
 KAKAO_CLIENT_SECRET=
+KAKAO_ADMIN_KEY=
 KAKAO_REDIRECT_URI=http://localhost:8080/api/auth/kakao/callback
 
 # ========================================
@@ -53,7 +65,6 @@ KAKAO_REDIRECT_URI=http://localhost:8080/api/auth/kakao/callback
 # Google Cloud
 # ========================================
 GOOGLE_CLOUD_PROJECT=
-GOOGLE_APPLICATION_CREDENTIALS=
 # GCS 버킷 설정
 GCS_PUBLIC_BUCKET=
 GCS_PRIVATE_BUCKET=
@@ -65,8 +76,8 @@ GCS_SERVICE_ACCOUNT_EMAIL=
 # ========================================
 # JPA 설정
 # ========================================
-# 로컬: update (엔티티 변경 시 자동 반영)
-# 배포: validate (스키마 검증만)
+# 로컬/dev: update (엔티티 변경 시 자동 반영)
+# prod: validate (스키마 검증만)
 SPRING_JPA_HIBERNATE_DDL_AUTO=update
 
 # ========================================
@@ -85,6 +96,8 @@ REPLICATE_API_KEY=
 REPLICATE_MODEL_VERSION=a5b13068cc81a89a4fbeefeccc774869fcb34df4dbc92c1555e0f2771d49dde7
 # 웹훅 콜백 URL (로컬: ngrok 사용, 배포: 실제 도메인)
 WEBHOOK_BASE_URL=http://localhost:8080/api
+# 웹훅 시크릿 (Replicate 콘솔에서 설정)
+REPLICATE_WEBHOOK_SECRET=
 
 # ========================================
 # CORS (허용 도메인)
@@ -104,7 +117,9 @@ LOGIN_SECRET_KEY=local-dummy-key
 # 로컬에서는 비활성화됨 (application-local.yml)
 SENTRY_DSN=
 
-# Sendon(카카오톡 알림톡 대행사)
+# ========================================
+# Sendon (카카오톡 알림톡 대행사)
+# ========================================
 SENDON_ID=
 SENDON_API_KEY=
 SENDON_SENDER_KEY=
@@ -114,4 +129,13 @@ SENDON_PHONE_TEMPLATE_CODE=
 # Discord (에러 알림)
 # ========================================
 # Webhook URL: Discord 서버 설정 → 연동 → 웹후크 만들기
+# prod에서만 활성화 (application-prod.yml)
 DISCORD_WEBHOOK_URL=
+
+# ========================================
+# 배포 서버 전용 (로컬에서는 불필요)
+# ========================================
+# Cloudflare Tunnel 토큰 (docker-compose.infra.yml에서 사용)
+# TUNNEL_TOKEN=
+# 리버스 프록시 뒤에서 X-Forwarded-* 헤더 신뢰
+# SERVER_FORWARD_HEADERS_STRATEGY=framework


### PR DESCRIPTION
## Summary

Blue-Green 배포 및 Redis 캐시 도입 이후 추가된 환경변수들이 `.env.example`에 반영되지 않은 부분을 최신화

## Changes

- Redis 환경변수 추가 (`REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`)
- `KAKAO_ADMIN_KEY` 추가 (기존 누락)
- `REPLICATE_WEBHOOK_SECRET` 추가 (기존 누락)
- 배포 서버 전용 변수 안내 추가 (`TUNNEL_TOKEN`, `SERVER_FORWARD_HEADERS_STRATEGY`)
- `GOOGLE_APPLICATION_CREDENTIALS` 제거 (GCE 메타데이터/ADC로 자동 인증, 실제 미사용)
- 프로필 설명 최신화 (local/dev/prod 3환경 체계)
- 섹션 헤더 및 주석 정리

## Type of Change

- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [x] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues

Closes #375

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes

`.env.prod`, `.env.dev`는 Git에 커밋되지 않으므로 별도로 로컬 수정 + GitHub Secrets(ENV_PROD, ENV_DEV) 업데이트가 필요합니다.