### PR TITLE
[FEAT] AI 사진 복원 모델을 FLUX.1 Kontext Pro로 전환 (#377)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,10 +91,10 @@ PORTONE_API_SECRET=
 # ========================================
 # API 키: https://replicate.com/account/api-tokens
 REPLICATE_API_KEY=
-# Inpainting 모델 버전 (FLUX.1 Kontext Pro - 필름 사진 복원 특화)
-# https://replicate.com/black-forest-labs/flux-kontext-pro
-# 비용: $0.04/image, 속도: 4.4초, 품질: 2025년 최신 모델
-REPLICATE_MODEL_VERSION=flux-kontext-pro
+# Inpainting 모델 버전 (FLUX.1 Fill [pro] - 마스크 기반 이미지 인페인팅)
+# https://replicate.com/black-forest-labs/flux-fill-pro
+# 비용: $0.05/image (₩70), 속도: 빠름, 품질: 최신 모델
+REPLICATE_MODEL_VERSION=c96684b78bc3e49cf4c8e4bc03d3cea723a1942042b9d016ca6fbf3fd478c93e
 # 웹훅 콜백 URL (로컬: ngrok 사용, 배포: 실제 도메인)
 WEBHOOK_BASE_URL=http://localhost:8080/api
 # 웹훅 시크릿 (Replicate 콘솔에서 설정)

--- a/.env.example
+++ b/.env.example
@@ -91,9 +91,10 @@ PORTONE_API_SECRET=
 # ========================================
 # API 키: https://replicate.com/account/api-tokens
 REPLICATE_API_KEY=
-# Inpainting 모델 버전 (SDXL Inpainting - 원본 비율 유지, max 1024px)
-# https://replicate.com/lucataco/sdxl-inpainting
-REPLICATE_MODEL_VERSION=a5b13068cc81a89a4fbeefeccc774869fcb34df4dbc92c1555e0f2771d49dde7
+# Inpainting 모델 버전 (FLUX.1 Kontext Pro - 필름 사진 복원 특화)
+# https://replicate.com/black-forest-labs/flux-kontext-pro
+# 비용: $0.04/image, 속도: 4.4초, 품질: 2025년 최신 모델
+REPLICATE_MODEL_VERSION=flux-kontext-pro
 # 웹훅 콜백 URL (로컬: ngrok 사용, 배포: 실제 도메인)
 WEBHOOK_BASE_URL=http://localhost:8080/api
 # 웹훅 시크릿 (Replicate 콘솔에서 설정)

--- a/src/main/java/com/finders/api/domain/photo/enums/RestorationTier.java
+++ b/src/main/java/com/finders/api/domain/photo/enums/RestorationTier.java
@@ -6,8 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum RestorationTier {
-    /** FLUX.1 Fill [pro] - mask 기반 인페인팅, $0.05/image, 2토큰 */
-    BASIC("기본 복원", 2, "flux-fill-pro");
+    /** FLUX.1 Fill [pro] - mask 기반 인페인팅, $0.05/image, 1토큰 (임시) */
+    BASIC("기본 복원", 1, "flux-fill-pro");
 
     private final String description;
     private final int tokenCost;

--- a/src/main/java/com/finders/api/domain/photo/enums/RestorationTier.java
+++ b/src/main/java/com/finders/api/domain/photo/enums/RestorationTier.java
@@ -1,0 +1,15 @@
+package com.finders.api.domain.photo.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RestorationTier {
+    /** FLUX.1 Fill [pro] - mask 기반 인페인팅, $0.05/image, 2토큰 */
+    BASIC("기본 복원", 2, "flux-fill-pro");
+
+    private final String description;
+    private final int tokenCost;
+    private final String modelIdentifier;
+}

--- a/src/main/java/com/finders/api/domain/photo/service/command/PhotoRestorationCommandServiceImpl.java
+++ b/src/main/java/com/finders/api/domain/photo/service/command/PhotoRestorationCommandServiceImpl.java
@@ -31,7 +31,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Transactional
 public class PhotoRestorationCommandServiceImpl implements PhotoRestorationCommandService {
 
-    private static final int RESTORATION_TOKEN_COST = 1;
+    private static final int RESTORATION_TOKEN_COST = 2;  // FLUX Kontext Pro: 2토큰 (₩1,000)
     private static final int SIGNED_URL_EXPIRY_MINUTES = 60;
 
     private final PhotoRestorationRepository restorationRepository;

--- a/src/main/java/com/finders/api/domain/photo/service/command/PhotoRestorationCommandServiceImpl.java
+++ b/src/main/java/com/finders/api/domain/photo/service/command/PhotoRestorationCommandServiceImpl.java
@@ -10,7 +10,10 @@ import com.finders.api.domain.photo.repository.PhotoRestorationRepository;
 import com.finders.api.domain.photo.service.ImageMetadataService;
 import com.finders.api.global.exception.CustomException;
 import com.finders.api.global.response.ErrorCode;
+import com.finders.api.domain.photo.enums.RestorationTier;
+import com.finders.api.infra.replicate.FluxFillInput;
 import com.finders.api.infra.replicate.ReplicateClient;
+import com.finders.api.infra.replicate.ReplicateModelInput;
 import com.finders.api.infra.replicate.ReplicateResponse;
 import com.finders.api.infra.storage.StoragePath;
 import com.finders.api.infra.storage.StorageResponse;
@@ -31,7 +34,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Transactional
 public class PhotoRestorationCommandServiceImpl implements PhotoRestorationCommandService {
 
-    private static final int RESTORATION_TOKEN_COST = 2;  // FLUX Kontext Pro: 2토큰 (₩1,000)
     private static final int SIGNED_URL_EXPIRY_MINUTES = 60;
 
     private final PhotoRestorationRepository restorationRepository;
@@ -46,47 +48,43 @@ public class PhotoRestorationCommandServiceImpl implements PhotoRestorationComma
 
     @Override
     public RestorationResponse.Created createRestoration(Long memberId, RestorationRequest.Create request) {
-        // 1. 토큰 잔액 확인 (차감은 복원 완료 시점에)
-        if (!tokenQueryService.hasEnoughTokens(memberId, RESTORATION_TOKEN_COST)) {
+        RestorationTier tier = RestorationTier.BASIC;
+        int tokenCost = tier.getTokenCost();
+
+        if (!tokenQueryService.hasEnoughTokens(memberId, tokenCost)) {
             throw new CustomException(ErrorCode.INSUFFICIENT_TOKEN);
         }
 
-        // 2. 경로 검증 (프론트에서 전달받은 경로가 유효한지)
         validateRestorationPath(request.originalPath(), StoragePath.RESTORATION_ORIGINAL, memberId);
         validateRestorationPath(request.maskPath(), StoragePath.RESTORATION_MASK, memberId);
 
-        // 3. 복원 요청 저장 (토큰 차감은 완료 시점에)
         PhotoRestoration restoration = PhotoRestoration.builder()
                 .memberId(memberId)
                 .originalPath(request.originalPath())
                 .maskPath(request.maskPath())
-                .tokenUsed(RESTORATION_TOKEN_COST)
+                .tokenUsed(tokenCost)
                 .build();
 
         restoration = restorationRepository.save(restoration);
 
-        // 4. Replicate API 호출을 위한 Signed URL 생성
         String originalSignedUrl = storageService.getSignedUrl(request.originalPath(), SIGNED_URL_EXPIRY_MINUTES).url();
         String maskSignedUrl = storageService.getSignedUrl(request.maskPath(), SIGNED_URL_EXPIRY_MINUTES).url();
 
-        ReplicateResponse.Prediction prediction = replicateClient.createInpaintingPrediction(
-                originalSignedUrl,
-                maskSignedUrl
-        );
+        ReplicateModelInput modelInput = createModelInput(tier, originalSignedUrl, maskSignedUrl);
+        ReplicateResponse.Prediction prediction = replicateClient.createPrediction(modelInput);
 
-        // 5. 상태 업데이트
         restoration.startProcessing(prediction.id());
 
         int currentBalance = tokenQueryService.getBalance(memberId);
 
-        log.info("[PhotoRestorationCommandServiceImpl.createRestoration] Created: id={}, predictionId={}, currentBalance={}",
-                restoration.getId(), prediction.id(), currentBalance);
+        log.info("[PhotoRestorationCommandServiceImpl.createRestoration] Created: id={}, tier={}, predictionId={}, currentBalance={}",
+                restoration.getId(), tier, prediction.id(), currentBalance);
 
         return RestorationResponse.Created.builder()
                 .id(restoration.getId())
                 .status(restoration.getStatus())
-                .tokenUsed(RESTORATION_TOKEN_COST)
-                .remainingBalance(currentBalance)  // 아직 차감 전이므로 현재 잔액
+                .tokenUsed(tokenCost)
+                .remainingBalance(currentBalance)
                 .build();
     }
 
@@ -160,11 +158,12 @@ public class PhotoRestorationCommandServiceImpl implements PhotoRestorationComma
                 restoration.getId(), predictionId, errorMessage);
     }
 
-    /**
-     * 복원 경로 검증
-     * - 경로 형식이 올바른지
-     * - 본인의 memberId로 된 경로인지
-     */
+    private ReplicateModelInput createModelInput(RestorationTier tier, String imageUrl, String maskUrl) {
+        return switch (tier) {
+            case BASIC -> FluxFillInput.forRestoration(imageUrl, maskUrl);
+        };
+    }
+
     private void validateRestorationPath(String objectPath, StoragePath expectedType, Long memberId) {
         if (objectPath == null || objectPath.isBlank()) {
             throw new CustomException(ErrorCode.BAD_REQUEST, "이미지 경로가 비어있습니다.");
@@ -227,9 +226,6 @@ public class PhotoRestorationCommandServiceImpl implements PhotoRestorationComma
         }
     }
 
-    /**
-     * 복원된 이미지 결과 (경로 + 메타데이터)
-     */
     private record RestoredImageResult(String objectPath, Integer width, Integer height) {
     }
 }

--- a/src/main/java/com/finders/api/infra/replicate/FluxFillInput.java
+++ b/src/main/java/com/finders/api/infra/replicate/FluxFillInput.java
@@ -1,0 +1,49 @@
+package com.finders.api.infra.replicate;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record FluxFillInput(
+        String prompt,
+        String image,
+        String mask,
+        @JsonProperty("num_outputs")
+        Integer numOutputs,
+        @JsonProperty("num_inference_steps")
+        Integer numInferenceSteps,
+        Double guidance,
+        String megapixels,
+        @JsonProperty("output_format")
+        String outputFormat,
+        Integer seed
+) implements ReplicateModelInput {
+
+    private static final String MODEL_VERSION = "c96684b78bc3e49cf4c8e4bc03d3cea723a1942042b9d016ca6fbf3fd478c93e";
+    private static final String DEFAULT_PROMPT = "restore damaged analog film photo, fix light leak and scratches, preserve film grain texture, maintain natural colors and vintage aesthetic";
+    private static final Integer DEFAULT_NUM_OUTPUTS = 1;
+    private static final Integer DEFAULT_NUM_INFERENCE_STEPS = 28;
+    private static final Double DEFAULT_GUIDANCE = 30.0;
+    private static final String DEFAULT_MEGAPIXELS = "match_input";
+    private static final String DEFAULT_OUTPUT_FORMAT = "png";
+
+    public static FluxFillInput forRestoration(String imageUrl, String maskUrl) {
+        return FluxFillInput.builder()
+                .prompt(DEFAULT_PROMPT)
+                .image(imageUrl)
+                .mask(maskUrl)
+                .numOutputs(DEFAULT_NUM_OUTPUTS)
+                .numInferenceSteps(DEFAULT_NUM_INFERENCE_STEPS)
+                .guidance(DEFAULT_GUIDANCE)
+                .megapixels(DEFAULT_MEGAPIXELS)
+                .outputFormat(DEFAULT_OUTPUT_FORMAT)
+                .build();
+    }
+
+    @Override
+    public String modelVersion() {
+        return MODEL_VERSION;
+    }
+}

--- a/src/main/java/com/finders/api/infra/replicate/FluxKontextInput.java
+++ b/src/main/java/com/finders/api/infra/replicate/FluxKontextInput.java
@@ -1,0 +1,46 @@
+package com.finders.api.infra.replicate;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record FluxKontextInput(
+        @JsonProperty("input_image")
+        String inputImage,
+        String prompt,
+        @JsonProperty("aspect_ratio")
+        String aspectRatio,
+        @JsonProperty("output_format")
+        String outputFormat,
+        @JsonProperty("prompt_upsampling")
+        Boolean promptUpsampling,
+        @JsonProperty("safety_tolerance")
+        Integer safetyTolerance,
+        Integer seed
+) implements ReplicateModelInput {
+
+    private static final String MODEL_VERSION = "3b04064a22c483113223a8e15f5e7e9e23c2e37ac02ef182a4a4c09f49a7f0d9";
+    private static final String DEFAULT_PROMPT = "restore damaged analog film photo, fix light leak and scratches, preserve film grain texture, maintain natural colors and vintage aesthetic";
+    private static final String DEFAULT_ASPECT_RATIO = "match_input_image";
+    private static final String DEFAULT_OUTPUT_FORMAT = "png";
+    private static final Boolean DEFAULT_PROMPT_UPSAMPLING = false;
+    private static final Integer DEFAULT_SAFETY_TOLERANCE = 2;
+
+    public static FluxKontextInput forRestoration(String imageUrl, String maskUrl) {
+        return FluxKontextInput.builder()
+                .inputImage(imageUrl)
+                .prompt(DEFAULT_PROMPT)
+                .aspectRatio(DEFAULT_ASPECT_RATIO)
+                .outputFormat(DEFAULT_OUTPUT_FORMAT)
+                .promptUpsampling(DEFAULT_PROMPT_UPSAMPLING)
+                .safetyTolerance(DEFAULT_SAFETY_TOLERANCE)
+                .build();
+    }
+
+    @Override
+    public String modelVersion() {
+        return MODEL_VERSION;
+    }
+}

--- a/src/main/java/com/finders/api/infra/replicate/ReplicateClient.java
+++ b/src/main/java/com/finders/api/infra/replicate/ReplicateClient.java
@@ -24,13 +24,12 @@ public class ReplicateClient {
         this.properties = properties;
     }
 
-    public ReplicateResponse.Prediction createInpaintingPrediction(String imageUrl, String maskUrl) {
-        log.info("[ReplicateClient.createInpaintingPrediction] Creating prediction");
-        
+    public ReplicateResponse.Prediction createPrediction(ReplicateModelInput modelInput) {
+        log.info("[ReplicateClient.createPrediction] Creating prediction with model: {}",
+                modelInput.getClass().getSimpleName());
+
         ReplicateRequest.CreatePrediction request = ReplicateRequest.CreatePrediction.of(
-                properties.modelVersion(),
-                imageUrl,
-                maskUrl,
+                modelInput,
                 properties.getWebhookUrl()
         );
 
@@ -44,7 +43,7 @@ public class ReplicateClient {
                     .block();
 
         } catch (Exception e) {
-            log.error("[ReplicateClient.createInpaintingPrediction] Failed: {}", e.getMessage());
+            log.error("[ReplicateClient.createPrediction] Failed: {}", e.getMessage());
             throw new CustomException(ErrorCode.EXTERNAL_API_ERROR, "Replicate API 호출 실패: " + e.getMessage());
         }
     }

--- a/src/main/java/com/finders/api/infra/replicate/ReplicateModelInput.java
+++ b/src/main/java/com/finders/api/infra/replicate/ReplicateModelInput.java
@@ -1,0 +1,7 @@
+package com.finders.api.infra.replicate;
+
+public sealed interface ReplicateModelInput
+        permits FluxFillInput, FluxKontextInput {
+
+    String modelVersion();
+}

--- a/src/main/java/com/finders/api/infra/replicate/ReplicateRequest.java
+++ b/src/main/java/com/finders/api/infra/replicate/ReplicateRequest.java
@@ -35,50 +35,44 @@ public class ReplicateRequest {
     }
 
     /**
-     * SDXL Inpainting 입력 데이터
+     * FLUX.1 Kontext Pro 입력 데이터
      * <p>
-     * 모델: lucataco/sdxl-inpainting (SDXL 기반)
-     * - 원본 이미지 비율을 유지하면서 max 1024px 이내로 스케일링
-     * - SD 2.0 대비 고해상도/고품질 결과물
+     * 모델: black-forest-labs/flux-kontext-pro
+     * - 원본 이미지 비율 유지 (aspect_ratio: match_input_image)
+     * - 필름 사진 복원 특화
      *
-     * @see <a href="https://replicate.com/lucataco/sdxl-inpainting">Replicate 모델 페이지</a>
+     * @see <a href="https://replicate.com/black-forest-labs/flux-kontext-pro">Replicate 모델 페이지</a>
      */
     @Builder
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record Input(
-            String image,
-            String mask,
+            @JsonProperty("input_image")
+            String inputImage,
             String prompt,
-            @JsonProperty("negative_prompt")
-            String negativePrompt,
-            String scheduler,
-            @JsonProperty("guidance_scale")
-            Double guidanceScale,
-            Integer steps,
-            Double strength,
-            @JsonProperty("num_outputs")
-            Integer numOutputs,
+            @JsonProperty("aspect_ratio")
+            String aspectRatio,
+            @JsonProperty("output_format")
+            String outputFormat,
+            @JsonProperty("prompt_upsampling")
+            Boolean promptUpsampling,
+            @JsonProperty("safety_tolerance")
+            Integer safetyTolerance,
             Integer seed
     ) {
         private static final String DEFAULT_PROMPT = "restore damaged analog film photo, fix light leak and scratches, preserve film grain texture, maintain natural colors and vintage aesthetic";
-        private static final String DEFAULT_NEGATIVE_PROMPT = "monochrome, lowres, bad anatomy, worst quality, low quality";
-        private static final String DEFAULT_SCHEDULER = "K_EULER";
-        private static final Double DEFAULT_GUIDANCE_SCALE = 8.0;
-        private static final Integer DEFAULT_STEPS = 20;
-        private static final Double DEFAULT_STRENGTH = 0.7;
-        private static final Integer DEFAULT_NUM_OUTPUTS = 1;
+        private static final String DEFAULT_ASPECT_RATIO = "match_input_image";
+        private static final String DEFAULT_OUTPUT_FORMAT = "png";
+        private static final Boolean DEFAULT_PROMPT_UPSAMPLING = false;
+        private static final Integer DEFAULT_SAFETY_TOLERANCE = 2;
 
         public static Input forRestoration(String imageUrl, String maskUrl) {
             return Input.builder()
-                    .image(imageUrl)
-                    .mask(maskUrl)
+                    .inputImage(imageUrl)
                     .prompt(DEFAULT_PROMPT)
-                    .negativePrompt(DEFAULT_NEGATIVE_PROMPT)
-                    .scheduler(DEFAULT_SCHEDULER)
-                    .guidanceScale(DEFAULT_GUIDANCE_SCALE)
-                    .steps(DEFAULT_STEPS)
-                    .strength(DEFAULT_STRENGTH)
-                    .numOutputs(DEFAULT_NUM_OUTPUTS)
+                    .aspectRatio(DEFAULT_ASPECT_RATIO)
+                    .outputFormat(DEFAULT_OUTPUT_FORMAT)
+                    .promptUpsampling(DEFAULT_PROMPT_UPSAMPLING)
+                    .safetyTolerance(DEFAULT_SAFETY_TOLERANCE)
                     .build();
         }
     }

--- a/src/main/java/com/finders/api/infra/replicate/ReplicateRequest.java
+++ b/src/main/java/com/finders/api/infra/replicate/ReplicateRequest.java
@@ -2,78 +2,28 @@ package com.finders.api.infra.replicate;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Builder;
 
 import java.util.List;
 
-/**
- * Replicate API 요청 DTO
- */
 public class ReplicateRequest {
 
-    /**
-     * Prediction 생성 요청
-     */
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record CreatePrediction(
             String version,
-            Input input,
+            Object input,
             String webhook,
             @JsonProperty("webhook_events_filter")
             List<String> webhookEventsFilter
     ) {
-        public static CreatePrediction of(String version, String imageUrl, String maskUrl, String webhookUrl) {
+        public static CreatePrediction of(ReplicateModelInput modelInput, String webhookUrl) {
             String finalWebhook = (webhookUrl != null && webhookUrl.startsWith("https://")) ? webhookUrl : null;
-            
+
             return new CreatePrediction(
-                    version,
-                    Input.forRestoration(imageUrl, maskUrl),
+                    modelInput.modelVersion(),
+                    modelInput,
                     finalWebhook,
                     finalWebhook != null ? List.of("completed") : null
             );
-        }
-    }
-
-    /**
-     * FLUX.1 Kontext Pro 입력 데이터
-     * <p>
-     * 모델: black-forest-labs/flux-kontext-pro
-     * - 원본 이미지 비율 유지 (aspect_ratio: match_input_image)
-     * - 필름 사진 복원 특화
-     *
-     * @see <a href="https://replicate.com/black-forest-labs/flux-kontext-pro">Replicate 모델 페이지</a>
-     */
-    @Builder
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    public record Input(
-            @JsonProperty("input_image")
-            String inputImage,
-            String prompt,
-            @JsonProperty("aspect_ratio")
-            String aspectRatio,
-            @JsonProperty("output_format")
-            String outputFormat,
-            @JsonProperty("prompt_upsampling")
-            Boolean promptUpsampling,
-            @JsonProperty("safety_tolerance")
-            Integer safetyTolerance,
-            Integer seed
-    ) {
-        private static final String DEFAULT_PROMPT = "restore damaged analog film photo, fix light leak and scratches, preserve film grain texture, maintain natural colors and vintage aesthetic";
-        private static final String DEFAULT_ASPECT_RATIO = "match_input_image";
-        private static final String DEFAULT_OUTPUT_FORMAT = "png";
-        private static final Boolean DEFAULT_PROMPT_UPSAMPLING = false;
-        private static final Integer DEFAULT_SAFETY_TOLERANCE = 2;
-
-        public static Input forRestoration(String imageUrl, String maskUrl) {
-            return Input.builder()
-                    .inputImage(imageUrl)
-                    .prompt(DEFAULT_PROMPT)
-                    .aspectRatio(DEFAULT_ASPECT_RATIO)
-                    .outputFormat(DEFAULT_OUTPUT_FORMAT)
-                    .promptUpsampling(DEFAULT_PROMPT_UPSAMPLING)
-                    .safetyTolerance(DEFAULT_SAFETY_TOLERANCE)
-                    .build();
         }
     }
 }

--- a/src/main/java/com/finders/api/infra/replicate/ReplicateRequest.java
+++ b/src/main/java/com/finders/api/infra/replicate/ReplicateRequest.java
@@ -60,7 +60,7 @@ public class ReplicateRequest {
             Integer numOutputs,
             Integer seed
     ) {
-        private static final String DEFAULT_PROMPT = "restore damaged photo, high quality, realistic, natural colors";
+        private static final String DEFAULT_PROMPT = "restore damaged analog film photo, fix light leak and scratches, preserve film grain texture, maintain natural colors and vintage aesthetic";
         private static final String DEFAULT_NEGATIVE_PROMPT = "monochrome, lowres, bad anatomy, worst quality, low quality";
         private static final String DEFAULT_SCHEDULER = "K_EULER";
         private static final Double DEFAULT_GUIDANCE_SCALE = 8.0;


### PR DESCRIPTION
## Summary
AI 사진 복원 모델을 SDXL Inpainting에서 **FLUX.1 Fill [pro]**로 전환하고, 향후 다중 모델 지원을 위한 확장 가능한 아키텍처를 구현했습니다.

## Changes

### 1. 모델 전환 (FLUX Kontext Pro → FLUX Fill Pro)
- `.env.example`: REPLICATE_MODEL_VERSION을 FLUX Fill Pro로 변경
- **핵심 차이**: 텍스트 기반 편집 → **마스크 기반 인페인팅**
- 가격: $0.04 (₩56) → $0.05 (₩70)
- **토큰 비용**: 1개 유지 (향후 가격 정책 확정 후 조정)

### 2. 확장 가능한 아키텍처 구현
- `RestorationTier` enum: 티어 시스템 (BASIC, 향후 PREMIUM 추가 가능)
- `ReplicateModelInput` sealed interface: 타입 안전한 다형성
- `FluxFillInput` record: FLUX Fill Pro 전용 Input (mask 지원)
- `FluxKontextInput` record: 기존 호환성 유지
- Strategy Pattern: `createModelInput()` 메서드로 모델 선택

### 3. API 파라미터 변경
**제거 (FLUX Kontext Pro 전용):**
- `input_image`, `aspect_ratio`, `prompt_upsampling`, `safety_tolerance`

**추가 (FLUX Fill Pro 전용):**
- `image`, `mask` ✅ (마스크 기반 인페인팅)
- `num_outputs`, `num_inference_steps`, `guidance`, `megapixels`

## Type of Change
- [x] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [x] Refactoring (확장 가능한 아키텍처로 리팩토링)

## Related Issues
Closes #377

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [x] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [x] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes

### 변경 이유
1. **PM 기획 일치**: 필름 현상에서 안 나온 부분(빛번짐)을 마스크로 지정하여 복원
2. **품질 향상**: FLUX Fill Pro는 마스크 기반 정밀 인페인팅 전문 모델
3. **확장성**: 향후 Gemini 3 Pro 등 다른 모델 추가 시 최소 변경

### FLUX.1 Fill [pro] 특징
- **마스크 기반 인페인팅**: 사용자가 복원할 영역을 정확히 지정
- **원본 비율 유지**: `megapixels: "match_input"` (최대 1440×1440)
- **고품질 복원**: 필름 grain/texture 보존
- **속도**: 평균 9초
- **비용**: $0.05/image (₩70)

### 아키텍처 설계

#### Sealed Interface Pattern
```java
public sealed interface ReplicateModelInput 
    permits FluxFillInput, FluxKontextInput {
    String modelVersion();
}
```

#### Strategy Pattern (경량)
```java
private ReplicateModelInput createModelInput(RestorationTier tier, String imageUrl, String maskUrl) {
    return switch (tier) {
        case BASIC -> FluxFillInput.forRestoration(imageUrl, maskUrl);
        // 향후: case PREMIUM -> GeminiInput.forRestoration(imageUrl, maskUrl);
    };
}
```

#### 확장 시나리오
```java
// 1. RestorationTier enum에 PREMIUM 추가
PREMIUM("고급 복원", 5, "gemini-3-pro");

// 2. GeminiInput record 생성
public record GeminiInput(...) implements ReplicateModelInput { }

// 3. Switch expression에 case 추가
case PREMIUM -> GeminiInput.forRestoration(imageUrl, maskUrl);
```

**최소 변경으로 새 모델 추가 가능!**

### ⚠️ 중요: 모델 특성 차이

| 항목 | SDXL Inpainting | FLUX Kontext Pro | **FLUX Fill Pro** |
|------|----------------|------------------|-------------------|
| 복원 방식 | Mask 기반 | 텍스트 기반 | **Mask 기반** ✅ |
| Mask 지원 | ✅ | ❌ | **✅** |
| 크기 제한 | 512×512 고정 | 제한 없음 | 최대 1440×1440 |
| 가격 | $0.0048 (₩6.7) | $0.04 (₩56) | **$0.05 (₩70)** |
| 품질 | ⭐⭐ | ⭐⭐⭐⭐ | **⭐⭐⭐⭐** |

### 💰 토큰 비용 정책
- **현재**: 1토큰 (₩500) - 기존 정책 유지
- **향후**: 가격 정책 확정 후 조정 예정
- **마진**: 1토큰 기준 약 86% (₩70 비용, ₩500 수익)

### 참고 자료
- [FLUX Fill Pro - Replicate](https://replicate.com/black-forest-labs/flux-fill-pro)
- [공식 문서](https://docs.bfl.ai/flux_tools/flux_1_fill)
- [API 스키마](https://replicate.com/black-forest-labs/flux-fill-pro/api/schema)

### 커밋 히스토리
1. `846b12db`: 초기 FLUX Kontext Pro 모델 전환
2. `460e7587`: FLUX Kontext Pro API 파라미터 적용
3. `0e772751`: FLUX Fill Pro 전환 + 확장 가능한 아키텍처 구현
4. `925de3d0`: 토큰 비용 1개로 임시 설정 (가격 정책 확정 대기)
