### PR TITLE
[FEAT] 현상소 공지 API response dto에 시작, 끝 날짜 추가 (#381)

### DIFF
--- a/src/main/java/com/finders/api/domain/store/dto/response/PhotoLabNoticeResponse.java
+++ b/src/main/java/com/finders/api/domain/store/dto/response/PhotoLabNoticeResponse.java
@@ -3,6 +3,8 @@ package com.finders.api.domain.store.dto.response;
 import com.finders.api.domain.store.enums.NoticeType;
 import lombok.Builder;
 
+import java.time.LocalDate;
+
 public class PhotoLabNoticeResponse {
 
     @Builder
@@ -10,7 +12,9 @@ public class PhotoLabNoticeResponse {
             Long photoLabId,
             String photoLabName,
             String noticeTitle,
-            NoticeType noticeType
+            NoticeType noticeType,
+            LocalDate startDate,
+            LocalDate endDate
     ) {
     }
 }

--- a/src/main/java/com/finders/api/domain/store/dto/response/PhotoLabNoticeResponse.java
+++ b/src/main/java/com/finders/api/domain/store/dto/response/PhotoLabNoticeResponse.java
@@ -1,5 +1,6 @@
 package com.finders.api.domain.store.dto.response;
 
+import com.finders.api.domain.store.entity.PhotoLabNotice;
 import com.finders.api.domain.store.enums.NoticeType;
 import lombok.Builder;
 
@@ -16,5 +17,15 @@ public class PhotoLabNoticeResponse {
             LocalDate startDate,
             LocalDate endDate
     ) {
+        public static Rolling from(PhotoLabNotice notice, String photoLabName) {
+            return Rolling.builder()
+                    .photoLabId(notice.getPhotoLab().getId())
+                    .photoLabName(photoLabName)
+                    .noticeTitle(notice.getTitle())
+                    .noticeType(notice.getNoticeType())
+                    .startDate(notice.getStartDate())
+                    .endDate(notice.getEndDate())
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/finders/api/domain/store/service/query/PhotoLabQueryServiceImpl.java
+++ b/src/main/java/com/finders/api/domain/store/service/query/PhotoLabQueryServiceImpl.java
@@ -68,8 +68,6 @@ public class PhotoLabQueryServiceImpl implements PhotoLabQueryService {
     private final MemberAgreementQueryService memberAgreementQueryService;
     private final StorageService storageService;
     private final RegionRepository regionRepository;
-
-    // 커뮤니티 현상소 검색 관련
     private final PhotoLabRepository photoLabRepository;
     private static final String DISTANCE_FORMAT_KM = "%.1fkm";
 
@@ -318,7 +316,7 @@ public class PhotoLabQueryServiceImpl implements PhotoLabQueryService {
         return resolved.isEmpty() ? null : List.copyOf(resolved);
     }
 
-    // 커뮤니티 현상소 검색
+    //커뮤니티 현상소 검색
     @Override
     public PhotoLabResponse.PhotoLabSearchListDTO searchCommunityPhotoLabs(
             PhotoLabRequest.PhotoLabCommunitySearchRequest request
@@ -401,6 +399,8 @@ public class PhotoLabQueryServiceImpl implements PhotoLabQueryService {
                         .photoLabName(photoLabNameById.get(notice.getPhotoLab().getId()))
                         .noticeTitle(notice.getTitle())
                         .noticeType(notice.getNoticeType())
+                        .startDate(notice.getStartDate())
+                        .endDate(notice.getEndDate())
                         .build())
                 .toList();
     }

--- a/src/main/java/com/finders/api/domain/store/service/query/PhotoLabQueryServiceImpl.java
+++ b/src/main/java/com/finders/api/domain/store/service/query/PhotoLabQueryServiceImpl.java
@@ -68,6 +68,8 @@ public class PhotoLabQueryServiceImpl implements PhotoLabQueryService {
     private final MemberAgreementQueryService memberAgreementQueryService;
     private final StorageService storageService;
     private final RegionRepository regionRepository;
+
+    // 커뮤니티 현상소 검색 관련
     private final PhotoLabRepository photoLabRepository;
     private static final String DISTANCE_FORMAT_KM = "%.1fkm";
 
@@ -316,7 +318,7 @@ public class PhotoLabQueryServiceImpl implements PhotoLabQueryService {
         return resolved.isEmpty() ? null : List.copyOf(resolved);
     }
 
-    //커뮤니티 현상소 검색
+    // 커뮤니티 현상소 검색
     @Override
     public PhotoLabResponse.PhotoLabSearchListDTO searchCommunityPhotoLabs(
             PhotoLabRequest.PhotoLabCommunitySearchRequest request
@@ -394,14 +396,10 @@ public class PhotoLabQueryServiceImpl implements PhotoLabQueryService {
                 .findByPhotoLab_IdInAndIsActiveTrueOrderByCreatedAtDescIdDesc(photoLabIds);
 
         return notices.stream()
-                .map(notice -> PhotoLabNoticeResponse.Rolling.builder()
-                        .photoLabId(notice.getPhotoLab().getId())
-                        .photoLabName(photoLabNameById.get(notice.getPhotoLab().getId()))
-                        .noticeTitle(notice.getTitle())
-                        .noticeType(notice.getNoticeType())
-                        .startDate(notice.getStartDate())
-                        .endDate(notice.getEndDate())
-                        .build())
+                .map(notice -> PhotoLabNoticeResponse.Rolling.from(
+                        notice,
+                        photoLabNameById.get(notice.getPhotoLab().getId())
+                ))
                 .toList();
     }
 


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
<!-- 변경 사항을 간단히 설명해주세요 -->
- 메인페이지에 사용될 현상소 공지를 위해서 response dto에 start, end date를 추가합니다

## Changes
<!-- 변경된 내용을 목록으로 작성해주세요 -->
  - src/main/java/com/finders/api/domain/store/dto/response/PhotoLabNoticeResponse.java:16
  - src/main/java/com/finders/api/domain/store/dto/response/PhotoLabNoticeResponse.java:17
    Rolling 응답 record에 LocalDate startDate, LocalDate endDate 추가
  - src/main/java/com/finders/api/domain/store/service/query/PhotoLabQueryServiceImpl.java:400
  - src/main/java/com/finders/api/domain/store/service/query/PhotoLabQueryServiceImpl.java:401
    /photo-labs/notices 매핑 시 .startDate(notice.getStartDate()), .endDate(notice.getEndDate()) 추가



## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->
Close #381 

## Checklist
<!-- PR 제출 전 확인사항 -->
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [x] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [x] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다


## Screenshots (Optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
<img width="610" height="541" alt="image" src="https://github.com/user-attachments/assets/706a4d14-8091-4f37-bcef-2559a1452842" />


## Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->
- 현상소의 공지 타입이 GENERAL인 경우에는 날짜가 null값이 들어가 있는데 이터 정제 시에 이 부분에도 날짜를 기입해야 할 것 같습니다!
