### PR TITLE
[FIX] Dev deploy 권한/환경변수 갱신 실패 수정 (#386)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -64,25 +64,34 @@ jobs:
 
       - name: Refresh Environment Variables from Secret Manager
         run: |
+          # NOTE:
+          # - List/access secrets on the GitHub runner (WIF auth)
+          # - Upload the resulting env file to the VM and move it with sudo
+          : > .env.dev
+          gcloud secrets list \
+            --project='${{ secrets.GCP_PROJECT_ID }}' \
+            --filter='labels.env=dev' \
+            --format='value(name)' \
+          | while read -r SECRET_NAME; do
+              VAR_NAME=$(echo "$SECRET_NAME" | sed 's/^app-dev-//' | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+              SECRET_VALUE=$(gcloud secrets versions access latest --project='${{ secrets.GCP_PROJECT_ID }}' --secret="$SECRET_NAME" 2>/dev/null) || continue
+              echo "$VAR_NAME=$SECRET_VALUE" >> .env.dev
+            done
+
+          gcloud compute scp .env.dev ${{ secrets.GCE_USER }}@${{ secrets.GCE_NAME }}:~/.env.dev \
+            --zone=${{ secrets.GCE_ZONE }} \
+            --project=${{ secrets.GCP_PROJECT_ID }} \
+            --tunnel-through-iap \
+            --quiet
+
           gcloud compute ssh ${{ secrets.GCE_USER }}@${{ secrets.GCE_NAME }} \
             --zone=${{ secrets.GCE_ZONE }} \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
             --quiet \
             --command="
-              sudo bash -c '
-                : > /projects/Finders/BE/.env.dev
-                gcloud secrets list \
-                  --project='\''${{ secrets.GCP_PROJECT_ID }}'\'' \
-                  --filter='\''labels.env=dev'\'' \
-                  --format='\''value(name)'\'' \
-                | while read -r SECRET_NAME; do
-                    VAR_NAME=\$(echo "\$SECRET_NAME" | sed 's/^app-dev-//' | tr "[:lower:]" "[:upper:]" | tr "-" "_")
-                    SECRET_VALUE=\$(gcloud secrets versions access latest --project='\''${{ secrets.GCP_PROJECT_ID }}'\'' --secret="\$SECRET_NAME" 2>/dev/null) || continue
-                    echo "\$VAR_NAME=\$SECRET_VALUE" >> /projects/Finders/BE/.env.dev
-                  done
-                chmod 600 /projects/Finders/BE/.env.dev
-              '
+              sudo mv ~/.env.dev /projects/Finders/BE/.env.dev
+              sudo chmod 600 /projects/Finders/BE/.env.dev
             "
 
       # 8. IAP를 통해 파일 전송 및 Blue-Green 배포 실행

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -70,17 +70,19 @@ jobs:
             --tunnel-through-iap \
             --quiet \
             --command="
-              : > /projects/Finders/BE/.env.dev
-              gcloud secrets list \
-                --project='${{ secrets.GCP_PROJECT_ID }}' \
-                --filter='labels.env=dev' \
-                --format='value(name)' \
-              | while read -r SECRET_NAME; do
-                  VAR_NAME=\$(echo \"\$SECRET_NAME\" | sed 's/^app-dev-//' | tr '[:lower:]' '[:upper:]' | tr '-' '_')
-                  SECRET_VALUE=\$(gcloud secrets versions access latest --project='${{ secrets.GCP_PROJECT_ID }}' --secret=\"\$SECRET_NAME\" 2>/dev/null) || continue
-                  echo \"\$VAR_NAME=\$SECRET_VALUE\" >> /projects/Finders/BE/.env.dev
-                done
-              chmod 600 /projects/Finders/BE/.env.dev
+              sudo bash -c '
+                : > /projects/Finders/BE/.env.dev
+                gcloud secrets list \
+                  --project='\''${{ secrets.GCP_PROJECT_ID }}'\'' \
+                  --filter='\''labels.env=dev'\'' \
+                  --format='\''value(name)'\'' \
+                | while read -r SECRET_NAME; do
+                    VAR_NAME=\$(echo "\$SECRET_NAME" | sed 's/^app-dev-//' | tr "[:lower:]" "[:upper:]" | tr "-" "_")
+                    SECRET_VALUE=\$(gcloud secrets versions access latest --project='\''${{ secrets.GCP_PROJECT_ID }}'\'' --secret="\$SECRET_NAME" 2>/dev/null) || continue
+                    echo "\$VAR_NAME=\$SECRET_VALUE" >> /projects/Finders/BE/.env.dev
+                  done
+                chmod 600 /projects/Finders/BE/.env.dev
+              '
             "
 
       # 8. IAP를 통해 파일 전송 및 Blue-Green 배포 실행

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,17 +70,19 @@ jobs:
             --tunnel-through-iap \
             --quiet \
             --command="
-              : > /projects/Finders/BE/.env.prod
-              gcloud secrets list \
-                --project='${{ secrets.GCP_PROJECT_ID }}' \
-                --filter='labels.env=prod' \
-                --format='value(name)' \
-              | while read -r SECRET_NAME; do
-                  VAR_NAME=\$(echo \"\$SECRET_NAME\" | sed 's/^app-prod-//' | tr '[:lower:]' '[:upper:]' | tr '-' '_')
-                  SECRET_VALUE=\$(gcloud secrets versions access latest --project='${{ secrets.GCP_PROJECT_ID }}' --secret=\"\$SECRET_NAME\" 2>/dev/null) || continue
-                  echo \"\$VAR_NAME=\$SECRET_VALUE\" >> /projects/Finders/BE/.env.prod
-                done
-              chmod 600 /projects/Finders/BE/.env.prod
+              sudo bash -c '
+                : > /projects/Finders/BE/.env.prod
+                gcloud secrets list \
+                  --project='\''${{ secrets.GCP_PROJECT_ID }}'\'' \
+                  --filter='\''labels.env=prod'\'' \
+                  --format='\''value(name)'\'' \
+                | while read -r SECRET_NAME; do
+                    VAR_NAME=\$(echo "\$SECRET_NAME" | sed 's/^app-prod-//' | tr "[:lower:]" "[:upper:]" | tr "-" "_")
+                    SECRET_VALUE=\$(gcloud secrets versions access latest --project='\''${{ secrets.GCP_PROJECT_ID }}'\'' --secret="\$SECRET_NAME" 2>/dev/null) || continue
+                    echo "\$VAR_NAME=\$SECRET_VALUE" >> /projects/Finders/BE/.env.prod
+                  done
+                chmod 600 /projects/Finders/BE/.env.prod
+              '
             "
 
       # 8. Blue-Green 배포 실행 (secrets are fetched from GCP Secret Manager by startup script)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,25 +64,34 @@ jobs:
 
       - name: Refresh Environment Variables from Secret Manager
         run: |
+          # NOTE:
+          # - List/access secrets on the GitHub runner (WIF auth)
+          # - Upload the resulting env file to the VM and move it with sudo
+          : > .env.prod
+          gcloud secrets list \
+            --project='${{ secrets.GCP_PROJECT_ID }}' \
+            --filter='labels.env=prod' \
+            --format='value(name)' \
+          | while read -r SECRET_NAME; do
+              VAR_NAME=$(echo "$SECRET_NAME" | sed 's/^app-prod-//' | tr '[:lower:]' '[:upper:]' | tr '-' '_')
+              SECRET_VALUE=$(gcloud secrets versions access latest --project='${{ secrets.GCP_PROJECT_ID }}' --secret="$SECRET_NAME" 2>/dev/null) || continue
+              echo "$VAR_NAME=$SECRET_VALUE" >> .env.prod
+            done
+
+          gcloud compute scp .env.prod ${{ secrets.GCE_USER }}@${{ secrets.GCE_NAME }}:~/.env.prod \
+            --zone=${{ secrets.GCE_ZONE }} \
+            --project=${{ secrets.GCP_PROJECT_ID }} \
+            --tunnel-through-iap \
+            --quiet
+
           gcloud compute ssh ${{ secrets.GCE_USER }}@${{ secrets.GCE_NAME }} \
             --zone=${{ secrets.GCE_ZONE }} \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
             --quiet \
             --command="
-              sudo bash -c '
-                : > /projects/Finders/BE/.env.prod
-                gcloud secrets list \
-                  --project='\''${{ secrets.GCP_PROJECT_ID }}'\'' \
-                  --filter='\''labels.env=prod'\'' \
-                  --format='\''value(name)'\'' \
-                | while read -r SECRET_NAME; do
-                    VAR_NAME=\$(echo "\$SECRET_NAME" | sed 's/^app-prod-//' | tr "[:lower:]" "[:upper:]" | tr "-" "_")
-                    SECRET_VALUE=\$(gcloud secrets versions access latest --project='\''${{ secrets.GCP_PROJECT_ID }}'\'' --secret="\$SECRET_NAME" 2>/dev/null) || continue
-                    echo "\$VAR_NAME=\$SECRET_VALUE" >> /projects/Finders/BE/.env.prod
-                  done
-                chmod 600 /projects/Finders/BE/.env.prod
-              '
+              sudo mv ~/.env.prod /projects/Finders/BE/.env.prod
+              sudo chmod 600 /projects/Finders/BE/.env.prod
             "
 
       # 8. Blue-Green 배포 실행 (secrets are fetched from GCP Secret Manager by startup script)

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -77,6 +77,7 @@ jobs:
       - name: Comment PR with Plan
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
+        continue-on-error: true
         with:
           script: |
             const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - 'infra/**'
       - '.github/workflows/terraform.yml'
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -215,6 +215,12 @@ resource "google_project_iam_member" "compute_sa_secretmanager_viewer" {
   member  = local.compute_sa_member
 }
 
+resource "google_project_iam_member" "compute_sa_secretmanager_secret_accessor" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = local.compute_sa_member
+}
+
 # =============================================================================
 # GCS bucket IAM bindings
 # =============================================================================

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -194,6 +194,28 @@ resource "google_service_account_iam_member" "sa_self_token_creator" {
 }
 
 # =============================================================================
+# CI/CD service account permissions
+#
+# GitHub Actions deploy workflow uses Workload Identity Federation (WIF) to
+# authenticate as `var.compute_sa_email`.
+# - Artifact Registry push requires `roles/artifactregistry.writer`
+# - Secret Manager env refresh uses `gcloud secrets list`, which requires
+#   `secretmanager.secrets.list` (covered by `roles/secretmanager.viewer`)
+# =============================================================================
+
+resource "google_project_iam_member" "compute_sa_artifactregistry_writer" {
+  project = var.project_id
+  role    = "roles/artifactregistry.writer"
+  member  = local.compute_sa_member
+}
+
+resource "google_project_iam_member" "compute_sa_secretmanager_viewer" {
+  project = var.project_id
+  role    = "roles/secretmanager.viewer"
+  member  = local.compute_sa_member
+}
+
+# =============================================================================
 # GCS bucket IAM bindings
 # =============================================================================
 


### PR DESCRIPTION
## Summary
- develop 배포 워크플로우가 Artifact Registry push / Secret Manager env refresh 단계에서 실패하던 원인을 수정합니다.

## Changes
- Terraform: GitHub Actions(WIF)로 사용하는 Compute Engine default SA에 아래 권한을 부여
  - roles/artifactregistry.writer
  - roles/secretmanager.viewer (secrets.list 필요)
- CD workflow: VM 내 /projects/Finders/BE/.env.* 파일을 sudo로 생성/갱신하도록 변경

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
- Fixes #386

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [ ] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes
- 실패 사례(run): https://github.com/Finders-Official/BE/actions/runs/21832156308/job/62993257424