### PR TITLE
[FIX] Docker build Gradle wrapper 다운로드 의존 제거 (#389)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,17 @@
 # ========================================
 # Stage 1: Build
 # ========================================
-FROM eclipse-temurin:21-jdk AS builder
+FROM gradle:8.11.1-jdk21 AS builder
 
-WORKDIR /app
+WORKDIR /home/gradle/project
 
-# Gradle wrapper 및 빌드 파일 복사
-COPY gradlew build.gradle settings.gradle ./
-COPY gradle gradle
-
-# Gradle 실행 권한 부여 및 의존성 캐시
-RUN chmod +x gradlew && ./gradlew dependencies --no-daemon
+# 빌드 파일 복사 및 의존성 캐시
+COPY build.gradle settings.gradle ./
+RUN gradle dependencies --no-daemon
 
 # 소스 코드 복사 및 빌드 (테스트 스킵)
 COPY src src
-RUN ./gradlew build -x test --no-daemon
+RUN gradle build -x test --no-daemon
 
 # ========================================
 # Stage 2: Runtime
@@ -25,7 +22,7 @@ WORKDIR /app
 
 # JAR 파일 복사 (⚠️ plain.jar 제외)
 ARG JAR_FILE=build/libs/*.jar
-COPY --from=builder /app/${JAR_FILE} app.jar
+COPY --from=builder /home/gradle/project/${JAR_FILE} app.jar
 
 # 포트 노출
 EXPOSE 8080


### PR DESCRIPTION
## Summary
Dev 배포 워크플로우에서 Docker build 중 Gradle wrapper 배포본 다운로드가 GitHub 500으로 실패하는 문제를 해결합니다.

## Changes
- Docker builder stage를 gradle:8.11.1-jdk21 기반으로 변경
- gradlew 대신 gradle 실행
- Gradle wrapper 다운로드 의존성 제거

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
Fixes #389

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Screenshots (Optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## Additional Notes
- GitHub Actions에서 Gradle wrapper 다운로드 시 간헐적 500 에러 발생
- Gradle preinstalled 이미지 사용으로 안정성 향상
