### PR TITLE
[FIX] 배포 스크립트 서버 경로 통일 (#391)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -103,7 +103,7 @@ jobs:
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
             --quiet \
-            --command="sudo mkdir -p /projects/Spring"
+            --command="sudo mkdir -p /projects/Finders/BE"
 
           # B. 파일을 홈 디렉토리(~)로 전송 (권한 에러 방지)
           gcloud compute scp docker-compose.infra.yml docker-compose.dev.yml \
@@ -120,10 +120,10 @@ jobs:
             --tunnel-through-iap \
             --quiet \
             --command="
-              sudo mv ~/docker-compose.infra.yml /projects/Spring/docker-compose.infra.yml
-              sudo mv ~/docker-compose.dev.yml /projects/Spring/docker-compose.dev.yml
+              sudo mv ~/docker-compose.infra.yml /projects/Finders/BE/docker-compose.infra.yml
+              sudo mv ~/docker-compose.dev.yml /projects/Finders/BE/docker-compose.dev.yml
 
-              cd /projects/Spring
+              cd /projects/Finders/BE
               DC='sudo docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml'
 
               sudo docker network create finders-network || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,7 +103,7 @@ jobs:
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
             --quiet \
-            --command="sudo mkdir -p /projects/Spring"
+            --command="sudo mkdir -p /projects/Finders/BE"
 
           # B-1. docker-compose.infra.yml 전송
           gcloud compute scp docker-compose.infra.yml ${{ secrets.GCE_USER }}@${{ secrets.GCE_NAME }}:~/docker-compose.infra.yml \
@@ -126,10 +126,10 @@ jobs:
             --tunnel-through-iap \
             --quiet \
             --command="
-              sudo mv ~/docker-compose.infra.yml /projects/Spring/docker-compose.infra.yml
-              sudo mv ~/docker-compose.prod.yml /projects/Spring/docker-compose.prod.yml
+              sudo mv ~/docker-compose.infra.yml /projects/Finders/BE/docker-compose.infra.yml
+              sudo mv ~/docker-compose.prod.yml /projects/Finders/BE/docker-compose.prod.yml
 
-              cd /projects/Spring
+              cd /projects/Finders/BE
               DC='sudo docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml'
 
               sudo docker network create finders-network || true


### PR DESCRIPTION
## Summary

배포 워크플로우에서 서버 경로가 `/projects/Spring`으로 되어 있어 Terraform이 생성하는 `/projects/Finders/BE/.env.prod` 경로와 불일치하는 문제를 수정합니다.

## Changes

- `deploy.yml`: `mkdir`, `mv`, `cd` 경로를 `/projects/Finders/BE`로 수정
- `deploy-dev.yml`: 동일하게 경로 통일

## Type of Change

- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues

Closes #391

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes

**원인**: `deploy.yml`이 docker-compose 파일을 `/projects/Spring/`에 배치하고 그 디렉토리에서 `--env-file .env.prod`를 상대경로로 참조 → `/projects/Spring/.env.prod`를 찾음. 하지만 Terraform startup script는 `.env.prod`를 `/projects/Finders/BE/`에 생성하므로 `couldn't find env file` 에러 발생.

**수정 범위**: `.github/workflows/deploy.yml`, `.github/workflows/deploy-dev.yml` (총 2파일, 경로 문자열만 변경)