### PR TITLE
[CHORE] Terraform deploy-config으로 CD 워크플로우 secrets 의존성 제거 (#393)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -49,6 +49,12 @@ jobs:
         with:
           project_id: '${{ secrets.GCP_PROJECT_ID }}'
 
+      - name: Load Deploy Config from Terraform
+        run: |
+          gcloud storage cp gs://finders-terraform-state/deploy-config.json /tmp/deploy-config.json
+          echo "GCE_NAME=$(jq -r .gce_name /tmp/deploy-config.json)" >> $GITHUB_ENV
+          echo "GCE_ZONE=$(jq -r .gce_zone /tmp/deploy-config.json)" >> $GITHUB_ENV
+
       # 6. Artifact Registry 인증
       - name: Authenticate to Artifact Registry
         run: |
@@ -78,14 +84,14 @@ jobs:
               echo "$VAR_NAME=$SECRET_VALUE" >> .env.dev
             done
 
-          gcloud compute scp .env.dev ${{ secrets.GCE_USER }}@${{ secrets.GCE_NAME }}:~/.env.dev \
-            --zone=${{ secrets.GCE_ZONE }} \
+          gcloud compute scp .env.dev ${{ env.GCE_NAME }}:~/.env.dev \
+            --zone=${{ env.GCE_ZONE }} \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
             --quiet
 
-          gcloud compute ssh ${{ secrets.GCE_USER }}@${{ secrets.GCE_NAME }} \
-            --zone=${{ secrets.GCE_ZONE }} \
+          gcloud compute ssh ${{ env.GCE_NAME }} \
+            --zone=${{ env.GCE_ZONE }} \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
             --quiet \
@@ -98,8 +104,8 @@ jobs:
       - name: 'Deploy to GCE via IAP'
         run: |
           # A. 서버 디렉토리 생성
-          gcloud compute ssh ${{ secrets.GCE_USER }}@${{ secrets.GCE_NAME }} \
-            --zone=${{ secrets.GCE_ZONE }} \
+          gcloud compute ssh ${{ env.GCE_NAME }} \
+            --zone=${{ env.GCE_ZONE }} \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
             --quiet \
@@ -107,15 +113,15 @@ jobs:
 
           # B. 파일을 홈 디렉토리(~)로 전송 (권한 에러 방지)
           gcloud compute scp docker-compose.infra.yml docker-compose.dev.yml \
-            ${{ secrets.GCE_USER }}@${{ secrets.GCE_NAME }}:~ \
-            --zone=${{ secrets.GCE_ZONE }} \
+            ${{ env.GCE_NAME }}:~ \
+            --zone=${{ env.GCE_ZONE }} \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
             --quiet
 
           # C. Blue-Green 배포 실행
-          gcloud compute ssh ${{ secrets.GCE_USER }}@${{ secrets.GCE_NAME }} \
-            --zone=${{ secrets.GCE_ZONE }} \
+          gcloud compute ssh ${{ env.GCE_NAME }} \
+            --zone=${{ env.GCE_ZONE }} \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
             --quiet \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,12 @@ jobs:
         with:
           project_id: '${{ secrets.GCP_PROJECT_ID }}'
 
+      - name: Load Deploy Config from Terraform
+        run: |
+          gcloud storage cp gs://finders-terraform-state/deploy-config.json /tmp/deploy-config.json
+          echo "GCE_NAME=$(jq -r .gce_name /tmp/deploy-config.json)" >> $GITHUB_ENV
+          echo "GCE_ZONE=$(jq -r .gce_zone /tmp/deploy-config.json)" >> $GITHUB_ENV
+
       # 6. Artifact Registry 인증
       - name: Authenticate to Artifact Registry
         run: |
@@ -78,14 +84,14 @@ jobs:
               echo "$VAR_NAME=$SECRET_VALUE" >> .env.prod
             done
 
-          gcloud compute scp .env.prod ${{ secrets.GCE_USER }}@${{ secrets.GCE_NAME }}:~/.env.prod \
-            --zone=${{ secrets.GCE_ZONE }} \
+          gcloud compute scp .env.prod ${{ env.GCE_NAME }}:~/.env.prod \
+            --zone=${{ env.GCE_ZONE }} \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
             --quiet
 
-          gcloud compute ssh ${{ secrets.GCE_USER }}@${{ secrets.GCE_NAME }} \
-            --zone=${{ secrets.GCE_ZONE }} \
+          gcloud compute ssh ${{ env.GCE_NAME }} \
+            --zone=${{ env.GCE_ZONE }} \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
             --quiet \
@@ -98,30 +104,30 @@ jobs:
       - name: 'Deploy to GCE via IAP (Blue-Green)'
         run: |
           # A. 서버 디렉토리 생성
-          gcloud compute ssh ${{ secrets.GCE_USER }}@${{ secrets.GCE_NAME }} \
-            --zone=${{ secrets.GCE_ZONE }} \
+          gcloud compute ssh ${{ env.GCE_NAME }} \
+            --zone=${{ env.GCE_ZONE }} \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
             --quiet \
             --command="sudo mkdir -p /projects/Finders/BE"
 
           # B-1. docker-compose.infra.yml 전송
-          gcloud compute scp docker-compose.infra.yml ${{ secrets.GCE_USER }}@${{ secrets.GCE_NAME }}:~/docker-compose.infra.yml \
-            --zone=${{ secrets.GCE_ZONE }} \
+          gcloud compute scp docker-compose.infra.yml ${{ env.GCE_NAME }}:~/docker-compose.infra.yml \
+            --zone=${{ env.GCE_ZONE }} \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
             --quiet
 
           # B-2. docker-compose.prod.yml 전송
-          gcloud compute scp docker-compose.prod.yml ${{ secrets.GCE_USER }}@${{ secrets.GCE_NAME }}:~/docker-compose.prod.yml \
-            --zone=${{ secrets.GCE_ZONE }} \
+          gcloud compute scp docker-compose.prod.yml ${{ env.GCE_NAME }}:~/docker-compose.prod.yml \
+            --zone=${{ env.GCE_ZONE }} \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
             --quiet
 
           # C. Blue-Green 배포 명령어 실행
-          gcloud compute ssh ${{ secrets.GCE_USER }}@${{ secrets.GCE_NAME }} \
-            --zone=${{ secrets.GCE_ZONE }} \
+          gcloud compute ssh ${{ env.GCE_NAME }} \
+            --zone=${{ env.GCE_ZONE }} \
             --project=${{ secrets.GCP_PROJECT_ID }} \
             --tunnel-through-iap \
             --quiet \

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -118,10 +118,5 @@ jobs:
       - name: Export Deploy Config to GCS
         if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
         run: |
-          cat > /tmp/deploy-config.json << DEPLOY_EOF
-          {
-            "gce_name": "$(terraform output -raw gce_instance_name)",
-            "gce_zone": "$(terraform output -raw gce_zone)"
-          }
-          DEPLOY_EOF
+          terraform output -raw deploy_config > /tmp/deploy-config.json
           gcloud storage cp /tmp/deploy-config.json gs://finders-terraform-state/deploy-config.json

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -114,3 +114,14 @@ jobs:
       - name: Terraform Apply
         if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
         run: terraform apply -auto-approve -input=false -var-file=terraform.tfvars -lock-timeout=5m
+
+      - name: Export Deploy Config to GCS
+        if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+        run: |
+          cat > /tmp/deploy-config.json << DEPLOY_EOF
+          {
+            "gce_name": "$(terraform output -raw gce_instance_name)",
+            "gce_zone": "$(terraform output -raw gce_zone)"
+          }
+          DEPLOY_EOF
+          gcloud storage cp /tmp/deploy-config.json gs://finders-terraform-state/deploy-config.json

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,9 @@
+output "gce_instance_name" {
+  description = "GCE VM instance name (used by CD workflows)"
+  value       = module.compute.instance_name
+}
+
+output "gce_zone" {
+  description = "GCE VM zone (used by CD workflows)"
+  value       = var.zone
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,9 +1,7 @@
-output "gce_instance_name" {
-  description = "GCE VM instance name (used by CD workflows)"
-  value       = module.compute.instance_name
-}
-
-output "gce_zone" {
-  description = "GCE VM zone (used by CD workflows)"
-  value       = var.zone
+output "deploy_config" {
+  description = "Deployment configuration for CD workflows (JSON format)"
+  value = jsonencode({
+    gce_name = module.compute.instance_name
+    gce_zone = var.zone
+  })
 }


### PR DESCRIPTION
## Summary
Terraform output(GCE 인스턴스명/Zone)을 GCS deploy-config.json으로 내보내고, CD 워크플로우가 이를 로드하도록 변경해 GitHub Secrets의 `GCE_NAME`, `GCE_ZONE`, `GCE_USER` 의존성을 제거했습니다.

## Changes
- Terraform: `gce_instance_name`, `gce_zone` output 추가 및 apply 이후 `gs://finders-terraform-state/deploy-config.json` 업로드
- CD: 배포 워크플로우에서 deploy-config.json을 로드하여 `GCE_NAME`, `GCE_ZONE`를 `env`로 주입하고 OS Login 기반으로 `user@` 접두사 제거

## Type of Change
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [x] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
Closes #393

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Screenshots (Optional)
-

## Additional Notes
- WIF 관련 Secrets (`WIF_PROVIDER`, `WIF_SERVICE_ACCOUNT`, `GCP_PROJECT_ID`)는 그대로 유지합니다.