### PR TITLE
[CHORE] Secret Manager 환경별 JSON 시크릿 통합 (#398)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -70,19 +70,11 @@ jobs:
 
       - name: Refresh Environment Variables from Secret Manager
         run: |
-          # NOTE:
-          # - List/access secrets on the GitHub runner (WIF auth)
-          # - Upload the resulting env file to the VM and move it with sudo
-          : > .env.dev
-          gcloud secrets list \
+          gcloud secrets versions access latest \
             --project='${{ secrets.GCP_PROJECT_ID }}' \
-            --filter='labels.env=dev' \
-            --format='value(name)' \
-          | while read -r SECRET_NAME; do
-              VAR_NAME=$(echo "$SECRET_NAME" | sed 's/^app-dev-//' | tr '[:lower:]' '[:upper:]' | tr '-' '_')
-              SECRET_VALUE=$(gcloud secrets versions access latest --project='${{ secrets.GCP_PROJECT_ID }}' --secret="$SECRET_NAME" 2>/dev/null) || continue
-              echo "$VAR_NAME=$SECRET_VALUE" >> .env.dev
-            done
+            --secret='finders-dev-config' \
+          | jq -r 'to_entries[] | "\(.key | ascii_upcase)=\(.value)"' \
+          > .env.dev
 
           gcloud compute scp .env.dev ${{ env.GCE_NAME }}:~/.env.dev \
             --zone=${{ env.GCE_ZONE }} \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,19 +70,11 @@ jobs:
 
       - name: Refresh Environment Variables from Secret Manager
         run: |
-          # NOTE:
-          # - List/access secrets on the GitHub runner (WIF auth)
-          # - Upload the resulting env file to the VM and move it with sudo
-          : > .env.prod
-          gcloud secrets list \
+          gcloud secrets versions access latest \
             --project='${{ secrets.GCP_PROJECT_ID }}' \
-            --filter='labels.env=prod' \
-            --format='value(name)' \
-          | while read -r SECRET_NAME; do
-              VAR_NAME=$(echo "$SECRET_NAME" | sed 's/^app-prod-//' | tr '[:lower:]' '[:upper:]' | tr '-' '_')
-              SECRET_VALUE=$(gcloud secrets versions access latest --project='${{ secrets.GCP_PROJECT_ID }}' --secret="$SECRET_NAME" 2>/dev/null) || continue
-              echo "$VAR_NAME=$SECRET_VALUE" >> .env.prod
-            done
+            --secret='finders-prod-config' \
+          | jq -r 'to_entries[] | "\(.key | ascii_upcase)=\(.value)"' \
+          > .env.prod
 
           gcloud compute scp .env.prod ${{ env.GCE_NAME }}:~/.env.prod \
             --zone=${{ env.GCE_ZONE }} \

--- a/infra/secret-manager.tf
+++ b/infra/secret-manager.tf
@@ -1,0 +1,27 @@
+resource "google_secret_manager_secret" "prod_config" {
+  project   = var.project_id
+  secret_id = "finders-prod-config"
+
+  labels = {
+    env        = "prod"
+    managed-by = "terraform"
+  }
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret" "dev_config" {
+  project   = var.project_id
+  secret_id = "finders-dev-config"
+
+  labels = {
+    env        = "dev"
+    managed-by = "terraform"
+  }
+
+  replication {
+    auto {}
+  }
+}


### PR DESCRIPTION
## Summary
Secret Manager 개별 시크릿 60개(app-prod-* 32개, app-dev-* 28개)를 환경별 JSON 시크릿 2개로 통합하여 시크릿 관리 간소화 및 배포 속도 개선

## Changes
- `infra/modules/compute/main.tf`: startup script에서 `gcloud secrets list` 루프 → 단일 JSON fetch + `jq` 파싱으로 변경 (prod/dev 모두)
- `.github/workflows/deploy.yml`: 동일한 JSON fetch 패턴 적용 (finders-prod-config)
- `.github/workflows/deploy-dev.yml`: 동일한 JSON fetch 패턴 적용 (finders-dev-config)
- `infra/secret-manager.tf`: Terraform 셸 리소스 2개 추가 (값은 Terraform 외부 관리, state에 시크릿 값 미포함)

### 변경 전
```bash
gcloud secrets list --filter="labels.env=prod" | while read SECRET_NAME; do
  gcloud secrets versions access latest --secret="$SECRET_NAME"  # 32회 반복
done
```

### 변경 후
```bash
gcloud secrets versions access latest --secret="finders-prod-config" \
  | jq -r 'to_entries[] | "\(.key | ascii_upcase)=\(.value)"'  # 1회
```

## Type of Change
- [x] Chore (빌드, 설정 등 기타 변경)

## Related Issues
Closes #398

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다

## Additional Notes
- GCP Secret Manager에 `finders-prod-config`(32 keys), `finders-dev-config`(28 keys) JSON 시크릿 이미 생성 완료
- 구 개별 시크릿 60개는 이 PR 머지 + 배포 검증 후 별도 삭제 예정
- `terraform-ci` SA에 `secretmanager.secretAccessor` + `secretmanager.viewer` 역할 이미 부여됨 (#397)
- GitHub Actions runner에는 `jq`가 기본 설치되어 있고, GCE startup script에서도 이미 `jq` 설치 로직 존재