### PR TITLE
[FIX] Dev 환경 CORS 전체 Origin 허용 (#405)

### DIFF
--- a/src/main/java/com/finders/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/finders/api/global/config/SecurityConfig.java
@@ -121,7 +121,17 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(corsProperties.allowedOrigins());
+
+        List<String> origins = corsProperties.allowedOrigins();
+        if (origins.size() == 1 && "*".equals(origins.getFirst())) {
+            // CORS_ALLOWED_ORIGINS=* → 모든 Origin 허용 (dev 환경용)
+            // setAllowedOrigins(["*"])는 allowCredentials(true)와 동시 사용 불가하므로
+            // setAllowedOriginPatterns를 사용
+            configuration.setAllowedOriginPatterns(List.of("*"));
+        } else {
+            configuration.setAllowedOrigins(origins);
+        }
+
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);

--- a/src/main/java/com/finders/api/global/config/SecurityConfig.java
+++ b/src/main/java/com/finders/api/global/config/SecurityConfig.java
@@ -123,7 +123,7 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
 
         List<String> origins = corsProperties.allowedOrigins();
-        if (origins.size() == 1 && "*".equals(origins.getFirst())) {
+        if (List.of("*").equals(origins)) {
             // CORS_ALLOWED_ORIGINS=* → 모든 Origin 허용 (dev 환경용)
             // setAllowedOrigins(["*"])는 allowCredentials(true)와 동시 사용 불가하므로
             // setAllowedOriginPatterns를 사용


### PR DESCRIPTION
## Summary
`CORS_ALLOWED_ORIGINS=*` 설정 시 `setAllowedOriginPatterns(["*"])`로 자동 전환하여 dev 환경에서 모든 Origin 허용

## Changes
- `SecurityConfig.corsConfigurationSource()`에서 `*` 감지 → `allowedOriginPatterns` 모드 전환
- GCP Secret Manager `finders-dev-config`의 `cors_allowed_origins` 값을 `*`로 변경 완료
- prod 환경은 기존 명시적 Origin 목록 유지 (변경 없음)

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)

## Related Issues
Closes #405

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [x] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes
- Spring Security 제약: `setAllowedOrigins(["*"])`는 `allowCredentials(true)`와 동시 사용 불가 → `setAllowedOriginPatterns` 필수
- dev Secret Manager에 이미 반영 완료 (v3), 코드 배포 후 즉시 적용