### PR TITLE
[BUG] region API 관련 redis 역질렬화 오류 수정 (#422)

### DIFF
--- a/src/main/java/com/finders/api/domain/store/dto/response/PhotoLabRegionFilterCacheDTO.java
+++ b/src/main/java/com/finders/api/domain/store/dto/response/PhotoLabRegionFilterCacheDTO.java
@@ -1,0 +1,42 @@
+package com.finders.api.domain.store.dto.response;
+
+import java.util.List;
+
+public record PhotoLabRegionFilterCacheDTO(
+        List<Parent> parents,
+        List<Region> regions
+) {
+    public static PhotoLabRegionFilterCacheDTO from(PhotoLabRegionFilterResponse response) {
+        List<Parent> parentItems = response.parents().stream()
+                .map(item -> new Parent(item.parentId(), item.parentName(), item.photoLabCount()))
+                .toList();
+        List<Region> regionItems = response.regions().stream()
+                .map(item -> new Region(item.regionId(), item.regionName(), item.parentId()))
+                .toList();
+        return new PhotoLabRegionFilterCacheDTO(parentItems, regionItems);
+    }
+
+    public PhotoLabRegionFilterResponse toResponse() {
+        List<PhotoLabParentRegionCountResponse> parentItems = parents.stream()
+                .map(item -> new PhotoLabParentRegionCountResponse(item.parentId(), item.parentName(), item.photoLabCount()))
+                .toList();
+        List<PhotoLabRegionItemResponse> regionItems = regions.stream()
+                .map(item -> new PhotoLabRegionItemResponse(item.regionId(), item.regionName(), item.parentId()))
+                .toList();
+        return new PhotoLabRegionFilterResponse(parentItems, regionItems);
+    }
+
+    public record Parent(
+            Long parentId,
+            String parentName,
+            Long photoLabCount
+    ) {
+    }
+
+    public record Region(
+            Long regionId,
+            String regionName,
+            Long parentId
+    ) {
+    }
+}

--- a/src/main/java/com/finders/api/domain/store/service/PhotoLabService.java
+++ b/src/main/java/com/finders/api/domain/store/service/PhotoLabService.java
@@ -8,12 +8,12 @@ import com.finders.api.domain.store.entity.PhotoLab;
 import com.finders.api.domain.store.entity.Region;
 import com.finders.api.domain.store.repository.PhotoLabRepository;
 import com.finders.api.domain.store.repository.RegionRepository;
-import com.finders.api.global.config.RedisConfig;
+import com.finders.api.domain.store.service.query.PhotoLabRegionCacheService;
 import com.finders.api.global.exception.CustomException;
 import com.finders.api.global.response.ErrorCode;
+import com.finders.api.infra.redis.RedisCacheClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,9 +28,9 @@ public class PhotoLabService {
     private final PhotoLabRepository photoLabRepository;
     private final MemberOwnerRepository memberOwnerRepository;
     private final RegionRepository regionRepository;
+    private final RedisCacheClient redisCacheClient;
 
     @Transactional
-    @CacheEvict(value = RedisConfig.PHOTO_LAB_REGION_COUNTS_CACHE, key = RedisConfig.PHOTO_LAB_REGION_COUNTS_CACHE_KEY)
     public PhotoLabResponse.Create createPhotoLab(Long ownerId, PhotoLabRequest.Create request) {
         log.info("[PhotoLabService.createPhotoLab] ownerId: {}", ownerId);
 
@@ -56,6 +56,7 @@ public class PhotoLabService {
                 .build();
 
         photoLabRepository.save(photoLab);
+        redisCacheClient.delete(PhotoLabRegionCacheService.KEY);
         return PhotoLabResponse.Create.from(photoLab);
     }
 }

--- a/src/main/java/com/finders/api/domain/store/service/query/PhotoLabQueryServiceImpl.java
+++ b/src/main/java/com/finders/api/domain/store/service/query/PhotoLabQueryServiceImpl.java
@@ -12,9 +12,7 @@ import com.finders.api.domain.store.dto.response.PhotoLabListResponse;
 import com.finders.api.domain.store.dto.response.PhotoLabNoticeResponse;
 import com.finders.api.domain.store.dto.response.PhotoLabPreviewResponse;
 import com.finders.api.domain.store.dto.response.PhotoLabResponse;
-import com.finders.api.domain.store.dto.response.PhotoLabParentRegionCountResponse;
 import com.finders.api.domain.store.dto.response.PhotoLabRegionFilterResponse;
-import com.finders.api.domain.store.dto.response.PhotoLabRegionItemResponse;
 import com.finders.api.domain.store.entity.PhotoLab;
 import com.finders.api.domain.store.entity.PhotoLabImage;
 import com.finders.api.domain.store.entity.PhotoLabNotice;
@@ -29,14 +27,12 @@ import com.finders.api.domain.store.repository.RegionRepository;
 import com.finders.api.domain.store.repository.PhotoLabTagQueryRepository;
 import com.finders.api.domain.terms.enums.TermsType;
 import com.finders.api.domain.terms.service.query.MemberAgreementQueryService;
-import com.finders.api.global.config.RedisConfig;
 import com.finders.api.global.exception.CustomException;
 import com.finders.api.global.response.ErrorCode;
 import com.finders.api.global.response.PagedResponse;
 import com.finders.api.global.response.SuccessCode;
 import com.finders.api.infra.storage.StorageService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -68,6 +64,7 @@ public class PhotoLabQueryServiceImpl implements PhotoLabQueryService {
     private final MemberAgreementQueryService memberAgreementQueryService;
     private final StorageService storageService;
     private final RegionRepository regionRepository;
+    private final PhotoLabRegionCacheService photoLabRegionCacheService;
 
     // 커뮤니티 현상소 검색 관련
     private final PhotoLabRepository photoLabRepository;
@@ -447,11 +444,9 @@ public class PhotoLabQueryServiceImpl implements PhotoLabQueryService {
         return PhotoLabFavoriteResponse.SliceResponse.from(cards);
     }
       
-    @Cacheable(value = RedisConfig.PHOTO_LAB_REGION_COUNTS_CACHE, key = RedisConfig.PHOTO_LAB_REGION_COUNTS_CACHE_KEY)
+    @Override
     public PhotoLabRegionFilterResponse getPhotoLabCountsByRegion() {
-        List<PhotoLabParentRegionCountResponse> parents = photoLabRepository.countPhotoLabsByTopRegion();
-        List<PhotoLabRegionItemResponse> regions = regionRepository.findAllRegionItems();
-        return new PhotoLabRegionFilterResponse(parents, regions);
+        return photoLabRegionCacheService.getPhotoLabCountsByRegion();
     }
 
 }

--- a/src/main/java/com/finders/api/domain/store/service/query/PhotoLabRegionCacheService.java
+++ b/src/main/java/com/finders/api/domain/store/service/query/PhotoLabRegionCacheService.java
@@ -1,0 +1,71 @@
+package com.finders.api.domain.store.service.query;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.finders.api.domain.store.dto.response.PhotoLabParentRegionCountResponse;
+import com.finders.api.domain.store.dto.response.PhotoLabRegionFilterCacheDTO;
+import com.finders.api.domain.store.dto.response.PhotoLabRegionFilterResponse;
+import com.finders.api.domain.store.dto.response.PhotoLabRegionItemResponse;
+import com.finders.api.domain.store.repository.PhotoLabRepository;
+import com.finders.api.domain.store.repository.RegionRepository;
+import com.finders.api.infra.redis.RedisCacheClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PhotoLabRegionCacheService {
+
+    public static final String KEY = "photoLabRegionCounts::all";
+    private static final Duration TTL = Duration.ofMinutes(60);
+
+    private final PhotoLabRepository photoLabRepository;
+    private final RegionRepository regionRepository;
+    private final RedisCacheClient redisCacheClient;
+    private final ObjectMapper objectMapper;
+
+    public PhotoLabRegionFilterResponse getPhotoLabCountsByRegion() {
+        return redisCacheClient.get(KEY)
+                .map(this::convertOrNull)
+                .filter(response -> response != null)
+                .orElseGet(this::loadFromDbAndCache);
+    }
+
+    private PhotoLabRegionFilterResponse loadFromDbAndCache() {
+        List<PhotoLabParentRegionCountResponse> parents = photoLabRepository.countPhotoLabsByTopRegion();
+        List<PhotoLabRegionItemResponse> regions = regionRepository.findAllRegionItems();
+        PhotoLabRegionFilterResponse response = new PhotoLabRegionFilterResponse(parents, regions);
+
+        redisCacheClient.set(KEY, PhotoLabRegionFilterCacheDTO.from(response), TTL);
+        return response;
+    }
+
+    @SuppressWarnings("unchecked")
+    private PhotoLabRegionFilterResponse convertOrNull(Object cached) {
+        try {
+            if (cached instanceof PhotoLabRegionFilterCacheDTO dto) {
+                return dto.toResponse();
+            }
+
+            if (cached instanceof PhotoLabRegionFilterResponse response) {
+                return response;
+            }
+
+            if (cached instanceof Map<?, ?> map) {
+                PhotoLabRegionFilterCacheDTO dto = objectMapper.convertValue((Map<String, Object>) map, PhotoLabRegionFilterCacheDTO.class);
+                return dto.toResponse();
+            }
+        } catch (RuntimeException e) {
+            log.warn("[PhotoLabRegionCacheService.convertOrNull] cache payload conversion failed. fallback to DB.", e);
+        }
+
+        log.warn("[PhotoLabRegionCacheService.convertOrNull] unexpected cache payload type: {}. fallback to DB.",
+                cached != null ? cached.getClass().getName() : "null");
+        return null;
+    }
+}

--- a/src/main/java/com/finders/api/domain/store/service/query/PhotoLabRegionCacheService.java
+++ b/src/main/java/com/finders/api/domain/store/service/query/PhotoLabRegionCacheService.java
@@ -48,25 +48,20 @@ public class PhotoLabRegionCacheService {
 
     @SuppressWarnings("unchecked")
     private PhotoLabRegionFilterResponse convertOrNull(Object cached) {
-        try {
-            if (cached instanceof PhotoLabRegionFilterCacheDTO dto) {
-                return dto.toResponse();
-            }
-
-            if (cached instanceof PhotoLabRegionFilterResponse response) {
-                return response;
-            }
-
-            if (cached instanceof Map<?, ?> map) {
+        if (cached instanceof Map<?, ?> map) {
+            try {
                 PhotoLabRegionFilterCacheDTO dto = objectMapper.convertValue((Map<String, Object>) map, PhotoLabRegionFilterCacheDTO.class);
                 return dto.toResponse();
+            } catch (RuntimeException e) {
+                log.warn("[PhotoLabRegionCacheService.convertOrNull] cache payload conversion failed. fallback to DB.", e);
+                return null;
             }
-        } catch (RuntimeException e) {
-            log.warn("[PhotoLabRegionCacheService.convertOrNull] cache payload conversion failed. fallback to DB.", e);
         }
 
-        log.warn("[PhotoLabRegionCacheService.convertOrNull] unexpected cache payload type: {}. fallback to DB.",
-                cached != null ? cached.getClass().getName() : "null");
+        if (cached != null) {
+            log.warn("[PhotoLabRegionCacheService.convertOrNull] unexpected cache payload type: {}. fallback to DB.",
+                    cached.getClass().getName());
+        }
         return null;
     }
 }

--- a/src/main/java/com/finders/api/domain/store/service/query/PhotoLabRegionCacheService.java
+++ b/src/main/java/com/finders/api/domain/store/service/query/PhotoLabRegionCacheService.java
@@ -22,7 +22,8 @@ import java.util.Map;
 public class PhotoLabRegionCacheService {
 
     public static final String KEY = "photoLabRegionCounts::all";
-    private static final Duration TTL = Duration.ofMinutes(60);
+    private static final long REGION_COUNTS_CACHE_TTL_MINUTES = 60L;
+    private static final Duration TTL = Duration.ofMinutes(REGION_COUNTS_CACHE_TTL_MINUTES);
 
     private final PhotoLabRepository photoLabRepository;
     private final RegionRepository regionRepository;

--- a/src/main/java/com/finders/api/infra/redis/RedisCacheClient.java
+++ b/src/main/java/com/finders/api/infra/redis/RedisCacheClient.java
@@ -33,4 +33,12 @@ public class RedisCacheClient {
             log.warn("[RedisCacheClient.set] Redis SET command failed for key: {}. This operation is best-effort.", key, e);
         }
     }
+
+    public void delete(String key) {
+        try {
+            redisTemplate.delete(key);
+        } catch (RuntimeException e) {
+            log.warn("[RedisCacheClient.delete] Redis DELETE command failed for key: {}. This operation is best-effort.", key, e);
+        }
+    }
 }


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

 ## Summary
  /api/photo-labs/regions에서 발생하던 Redis 캐시 역직렬화 ClassCastException( LinkedHashMap -> PhotoLabRegionFilterResponse 캐스팅 실패 )을 근본적으로 해결하기 위해, @Cacheable 기반 자동 캐시 경로를 제거하고
  PopularPostCacheService와 같은 수동 캐시 변환 구조로 전환했습니다.
  이번 변경으로 캐시 hit 시에도 타입 안전하게 응답 DTO로 복원되며, Redis 장애/변환 실패 시 DB fallback이 동작하도록 구성했습니다. 또한 포토랩 생성 시 region 집계 캐시를 명시적으로 무효화해 데이터 신선도를 유지합니다.

  ## Changes
  - getPhotoLabCountsByRegion()의 @Cacheable 제거 및 전용 캐시 서비스 위임으로 변경
      - src/main/java/com/finders/api/domain/store/service/query/PhotoLabQueryServiceImpl.java
  - region 캐시 전용 DTO 추가
      - src/main/java/com/finders/api/domain/store/dto/response/PhotoLabRegionFilterCacheDTO.java
      - 응답 DTO <-> 캐시 DTO 변환 로직 포함
  - region 캐시 전용 서비스 추가 (RedisCacheClient 기반)
      - src/main/java/com/finders/api/domain/store/service/query/PhotoLabRegionCacheService.java
      - 캐시 key: photoLabRegionCounts::all
      - 동작: cache read -> 안전 변환 -> 실패 시 DB fallback -> cache set(best effort)
  - Redis 캐시 클라이언트에 키 삭제 기능 추가
      - src/main/java/com/finders/api/infra/redis/RedisCacheClient.java
  - 포토랩 생성 시 region 캐시 수동 무효화로 변경
      - src/main/java/com/finders/api/domain/store/service/PhotoLabService.java
      - 기존 @CacheEvict 대신 redisCacheClient.delete(PhotoLabRegionCacheService.KEY) 사용
  - 빌드 검증
      - ./gradlew compileJava -x test 통과


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->
close #422 

## Checklist
<!-- PR 제출 전 확인사항 -->
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [x] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다


## Screenshots (Optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->


## Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

