### PR TITLE
[FIX] 프로필 이미지 외부 URL 수정 및 Redis 안정화 (#430)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,10 +11,16 @@
 services:
   # ── Redis (dev 전용) ──
   redis-dev:
-    image: redis:latest
+    image: redis:8.0-alpine
     container_name: finders-redis-dev
     restart: unless-stopped
-    command: redis-server --save 60 1 --loglevel warning
+    command: redis-server --save 60 1 --loglevel warning --maxmemory 128mb --maxmemory-policy allkeys-lru
+    volumes:
+      - redis-dev-data:/data
+    deploy:
+      resources:
+        limits:
+          memory: 256m
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s
@@ -92,3 +98,6 @@ services:
       - green
     networks:
       - finders-network
+
+volumes:
+  redis-dev-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,12 +54,18 @@ services:
   # Redis (캐싱 및 세션 관리)
   # ========================================
   redis:
-    image: redis:latest
+    image: redis:8.0-alpine
     container_name: finders-redis
     restart: unless-stopped
     ports:
       - "6379:6379"
-    command: redis-server --save 60 1 --loglevel warning
+    command: redis-server --save 60 1 --loglevel warning --maxmemory 128mb --maxmemory-policy allkeys-lru
+    volumes:
+      - redis-data:/data
+    deploy:
+      resources:
+        limits:
+          memory: 256m
     networks:
       - finders-network
     healthcheck:
@@ -103,6 +109,7 @@ services:
 
 volumes:
   mysql-data:
+  redis-data:
 
 networks:
   finders-network:

--- a/docs/architecture/ERD.md
+++ b/docs/architecture/ERD.md
@@ -1,53 +1,55 @@
 # Finders ERD
 
 > 필름 현상소 예약 서비스 데이터베이스 설계서
-> v3.1.0 | 2026-02-10
+> v3.2.0 | 2026-02-11
 
 ---
 
-## 테이블 목록 (36개)
+## 테이블 목록 (38개)
 
-| 도메인             | 테이블                       | 설명                           |
-|-----------------|---------------------------|------------------------------|
-| **member**      | `member`                  | 회원 Base (Joined Table 상속)    |
-|                 | `member_user`             | User 전용 (소셜 로그인 사용자, 크레딧 관련)  |
-|                 | `member_owner`            | Owner 전용 (현상소 사장님, 정산 계좌)    |
-|                 | `member_admin`            | Admin 전용 (관리자, 추후 확장)        |
-|                 | `social_account`          | 소셜 로그인 연동 - User 전용 (카카오/애플) |
-|                 | `member_address`          | 배송지 주소 - User 전용             |
-|                 | `member_device`           | FCM 디바이스 토큰 (푸시 알림용)         |
-|                 | `member_agreement`        | 약관 동의 이력                     |
-|                 | `terms`                   | 약관 버전 관리                     |
-|                 | `credit_history`          | AI 크레딧 충전/사용 내역 - User 전용     |
-|                 | `favorite_photo_lab`      | 관심 현상소                       |
-| **store**       | `photo_lab`               | 현상소 정보                       |
-|                 | `photo_lab_image`         | 현상소 이미지                      |
-|                 | `photo_lab_tag`           | 현상소-태그 조인 테이블                |
-|                 | `tag`                     | 현상소 태그                       |
-|                 | `photo_lab_notice`        | 현상소 공지사항                     |
-|                 | `photo_lab_business_hour` | 영업시간                         |
-|                 | `photo_lab_document`      | 사업자 증빙 서류                    |
-|                 | `region`                  | 지역 (시/도, 시/군/구)              |
-| **reservation** | `reservation`             | 예약 정보                        |
-| **photo**       | `development_order`       | 현상 주문                        |
-|                 | `scanned_photo`           | 스캔된 사진                       |
-|                 | `print_order`             | 인화 주문                        |
-|                 | `print_order_item`        | 인화 주문 상세                     |
-|                 | `print_order_photo`       | 인화 대상 사진 + 수량 (주문-스캔사진 매핑)   |
-|                 | `delivery`                | 배송 정보                        |
-|                 | `photo_restoration`       | AI 사진 복원 요청                  |
-| **community**   | `post`                    | 게시글/리뷰 (자가현상 여부 포함)          |
-|                 | `post_image`              | 게시글 이미지                      |
-|                 | `search_history`          | 최근 검색어 이력                    |
-|                 | `comments`                | 댓글                           |
-|                 | `post_like`               | 좋아요                          |
-| **inquiry**     | `inquiry`                 | 1:1 문의                       |
-|                 | `inquiry_image`           | 문의 첨부 이미지                    |
-|                 | `inquiry_reply`           | 문의 답변                        |
-| **common**      | `notice`                  | 공지사항                         |
-|                 | `promotion`               | 프로모션/배너                      |
-|                 | `notification`            | 알림                           |
-|                 | `payment`                 | 결제 정보 (포트원 V2)               |
+| 도메인             | 테이블                       | 설명                                |
+|-----------------|---------------------------|-----------------------------------|
+| **member**      | `member`                  | 회원 Base (Joined Table 상속)         |
+|                 | `member_user`             | User 전용 (소셜 로그인 사용자, 크레딧 관련)       |
+|                 | `member_owner`            | Owner 전용 (현상소 사장님, 정산 계좌)         |
+|                 | `member_admin`            | Admin 전용 (관리자, 추후 확장)             |
+|                 | `social_account`          | 소셜 로그인 연동 - User 전용 (카카오/애플)      |
+|                 | `member_address`          | 배송지 주소 - User 전용                  |
+|                 | `member_device`           | FCM 디바이스 토큰 ⛔ 데모데이 전 미구현         |
+|                 | `member_agreement`        | 약관 동의 이력                          |
+|                 | `terms`                   | 약관 버전 관리                          |
+|                 | `terms_social_mapping`    | 약관-소셜 태그 매핑 (카카오 동의 항목 연동)        |
+|                 | `credit_history`          | AI 크레딧 충전/사용 내역 - User 전용          |
+|                 | `favorite_photo_lab`      | 관심 현상소                            |
+| **store**       | `photo_lab`               | 현상소 정보                            |
+|                 | `photo_lab_image`         | 현상소 이미지                           |
+|                 | `photo_lab_tag`           | 현상소-태그 조인 테이블                     |
+|                 | `tag`                     | 현상소 태그                            |
+|                 | `photo_lab_notice`        | 현상소 공지사항                          |
+|                 | `photo_lab_business_hour` | 영업시간                              |
+|                 | `photo_lab_document`      | 사업자 증빙 서류                         |
+|                 | `region`                  | 지역 (시/도, 시/군/구)                   |
+| **reservation** | `reservation`             | 예약 정보                             |
+|                 | `reservation_slot`        | 예약 슬롯 (정원 관리)                     |
+| **photo**       | `development_order`       | 현상 주문                             |
+|                 | `scanned_photo`           | 스캔된 사진                            |
+|                 | `print_order`             | 인화 주문                             |
+|                 | `print_order_item`        | 인화 주문 상세                          |
+|                 | `print_order_photo`       | 인화 대상 사진 + 수량 (주문-스캔사진 매핑)        |
+|                 | `delivery`                | 배송 정보                             |
+|                 | `photo_restoration`       | AI 사진 복원 요청                       |
+| **community**   | `post`                    | 게시글/리뷰 (자가현상 여부 포함)               |
+|                 | `post_image`              | 게시글 이미지                           |
+|                 | `search_history`          | 최근 검색어 이력                         |
+|                 | `comments`                | 댓글                                |
+|                 | `post_like`               | 좋아요                               |
+| **inquiry**     | `inquiry`                 | 1:1 문의                            |
+|                 | `inquiry_image`           | 문의 첨부 이미지                         |
+|                 | `inquiry_reply`           | 문의 답변                             |
+| **common**      | `notice`                  | 공지사항 ⛔ 데모데이 전 미구현                 |
+|                 | `promotion`               | 프로모션/배너 ⛔ 데모데이 전 미구현              |
+|                 | `notification`            | 알림 ⛔ 데모데이 전 미구현                   |
+|                 | `payment`                 | 결제 정보 (포트원 V2)                    |
 
 ---
 
@@ -64,11 +66,12 @@ member (Base: Joined Table 상속)
    │
    └── 1:1 ─ member_admin (추후 확장)
 
-member ─┬─ 1:N ─ member_device (FCM 토큰, 공통)
-        ├─ 1:N ─ member_agreement ─── N:1 ─ terms (약관 버전, 공통)
-        ├─ 1:N ─ reservation ──── 0..1:1 ─ development_order ─┬─ 1:N ─ scanned_photo
-        │                                                     └─ 0..1:N ─ print_order ─┬─ 1:N ─ print_order_item
-        │                                                                              └─ 0..1:1 ─ delivery
+member ─┬─ 1:N ─ member_device (FCM 토큰, 공통) ⛔ 미구현
+        ├─ 1:N ─ member_agreement ─── N:1 ─ terms ─── 1:N ─ terms_social_mapping (소셜 태그 매핑)
+        ├─ 1:N ─ reservation ─── N:1 ─ reservation_slot (슬롯 정원 관리)
+        │    └── 0..1:1 ─ development_order ─┬─ 1:N ─ scanned_photo
+        │                                    └─ 0..1:N ─ print_order ─┬─ 1:N ─ print_order_item
+        │                                                             └─ 0..1:1 ─ delivery
         ├─ 1:N ─ development_order (현장 주문, 예약 없이)
         ├─ 1:N ─ print_order (현장 주문, 현상 없이)
         ├─ 1:N ─ photo_restoration (AI 복원, 크레딧 사용)
@@ -78,14 +81,15 @@ member ─┬─ 1:N ─ member_device (FCM 토큰, 공통)
         ├─ 1:N ─ favorite_photo_lab
         ├─ 1:N ─ inquiry ─┬─ 1:N ─ inquiry_image
         │                 └─ 1:N ─ inquiry_reply
-        ├─ 1:N ─ notification
+        ├─ 1:N ─ notification ⛔ 미구현
         └─ 1:N ─ payment (결제, 크레딧 구매)
 
 photo_lab ─┬─ 1:N ─ photo_lab_image
-           ├─ 1:1 ─ photo_lab_tag ─── 1:N ─ tag (현상소 태그)
+           ├─ N:N ─ tag (via photo_lab_tag 조인 테이블)
            ├─ 1:N ─ photo_lab_notice
            ├─ 1:N ─ photo_lab_business_hour
            ├─ 1:N ─ photo_lab_document (증빙서류)
+           ├─ 1:N ─ reservation_slot (시간대별 슬롯)
            ├─ 1:N ─ reservation
            ├─ 1:N ─ development_order (현장 주문)
            └─ 1:N ─ print_order (현장 주문)
@@ -97,63 +101,69 @@ photo_lab ─┬─ 1:N ─ photo_lab_image
 
 ```java
 // 회원 (Joined Table 상속)
-MemberType:USER,OWNER,ADMIN  // role 컬럼 (discriminator)
+MemberType:USER,OWNER,ADMIN           // role 컬럼 (discriminator)
 MemberStatus:ACTIVE,SUSPENDED,WITHDRAWN
-SocialProvider:KAKAO,APPLE    // User 전용
-DeviceType:IOS,ANDROID,WEB
+SocialProvider:KAKAO,APPLE             // User 전용
+DeviceType:IOS,ANDROID,WEB            // ⛔ 미구현
 
 // 현상소
 PhotoLabStatus:PENDING,ACTIVE,SUSPENDED,CLOSED
+NoticeType:GENERAL,EVENT,POLICY        // photo_lab_notice.notice_type
+DocumentType:BUSINESS_LICENSE,BUSINESS_PERMIT
 
 // 예약/주문
-ReservationStatus:RESERVED,COMPLETED,CANCELLED
+ReservationStatus:RESERVED,COMPLETED,CANCELED   // ⚠️ CANCELED (D 1개)
 DevelopmentOrderStatus:RECEIVED,DEVELOPING,SCANNING,COMPLETED
 PrintOrderStatus:PENDING,CONFIRMED,PRINTING,READY,SHIPPED,COMPLETED
 ReceiptMethod:PICKUP,DELIVERY
 DeliveryStatus:PENDING,PREPARING,SHIPPED,IN_TRANSIT,DELIVERED
 
+// 인화 옵션 (photo.enums.print 패키지)
+FilmType:SLIDE,COLOR_NEG,BLACK_WHITE              // extra(basePrice) 메서드 포함
+PaperType:ECO_GLOSSY_260,ECO_LUSTER_255,EPSON_SEMIGLOSSY_250  // extraPrice 포함
+PrintMethod:INKJET,CPRINT                          // extraPrice 포함
+PrintSize:SIZE_5x7,SIZE_6x8,SIZE_8x10,SIZE_8x12,A4,SIZE_10x15,SIZE_11x14  // basePrice 포함
+FrameType:WHITE_FRAME,NO_FRAME                     // extraPrice 포함
+
 // 커뮤니티
-PostStatus:ACTIVE,HIDDEN,DELETED
+CommunityStatus:ACTIVE,HIDDEN,DELETED  // Post, Comment 공용 (코드: CommunityStatus)
 
 // 문의
 InquiryStatus:PENDING,ANSWERED,CLOSED
 
-// 공지/알림
-NoticeType:GENERAL,EVENT,POLICY
+// 공지/알림 ⛔ 미구현
 NotificationType:ORDER,RESERVATION,COMMUNITY,MARKETING,NOTICE
 PromotionType:BANNER,POPUP,EVENT
 
-// 인화 옵션
-PaperType:GLOSSY,MATTE,SILK,LUSTER
-PrintMethod:INKJET,LASER,SILVER_HALIDE
-PrintProcess:NORMAL,BORDER,BORDERLESS
+// 약관
+TermsType:SERVICE,PRIVACY,LOCATION,SERVICE_INFO,MARKETING  // ⚠️ 코드 기준 (SERVICE_INFO 포함)
 
-// 약관/결제/복원 (v1.2.0 추가)
-AgreementType:TERMS,PRIVACY,MARKETING,LOCATION
-DocumentType:BUSINESS_LICENSE,BUSINESS_PERMIT
+// AI 복원
 RestorationStatus:PENDING,PROCESSING,COMPLETED,FAILED
 FeedbackRating:GOOD,BAD
+RestorationTier:PREMIUM                // 다중 모델 지원 (creditCost, modelIdentifier 포함)
 
 // 결제/크레딧 (v2.4.0 포트원 V2 전환)
-PaymentStatus:          // 포트원 V2 표준
-READY                 // 결제 대기
-        PENDING               // 결제 진행 중
-VIRTUAL_ACCOUNT_ISSUED // 가상계좌 발급됨
-        PAID                  // 결제 완료
-FAILED                // 결제 실패
-        PARTIAL_CANCELLED     // 부분 취소
-CANCELLED             // 전액 취소
+PaymentStatus:                         // 포트원 V2 표준
+  READY,                               // 결제 대기
+  PENDING,                             // 결제 진행 중
+  VIRTUAL_ACCOUNT_ISSUED,              // 가상계좌 발급됨
+  PAID,                                // 결제 완료
+  FAILED,                              // 결제 실패
+  PARTIAL_CANCELLED,                   // 부분 취소
+  CANCELLED                            // 전액 취소
 
-PaymentMethod:          // 포트원 V2 결제수단 (사용: 카드, 계좌이체, 가상계좌, 간편결제)
+PaymentMethod:                         // 포트원 V2 결제수단
   CARD, TRANSFER, VIRTUAL_ACCOUNT, EASY_PAY
 
-PgProvider:             // PG사/간편결제 제공자 (현재: KCP + 간편결제 3종)
-  KCP,                  // 메인 PG사 (카드, 계좌이체, 가상계좌)
-  KAKAOPAY, NAVERPAY, TOSSPAY  // 간편결제
+PgProvider:                            // PG사/간편결제 제공자 (현재: KCP + 간편결제 3종)
+  KCP,                                 // 메인 PG사 (카드, 계좌이체, 가상계좌)
+  KAKAOPAY, NAVERPAY, TOSSPAY         // 간편결제
   // 확장 가능: TOSSPAYMENTS, INICIS, NICE 등
 
 OrderType:CREDIT_PURCHASE,DEVELOPMENT_ORDER,PRINT_ORDER
 CreditHistoryType:SIGNUP_BONUS,REFRESH,PURCHASE,USE,REFUND
+CreditRelatedType:PHOTO_RESTORATION,PAYMENT  // credit_history.related_type
 ```
 
 ---
@@ -298,10 +308,8 @@ CREATE TABLE social_account
 CREATE TABLE member_address
 (
     id             BIGINT       NOT NULL AUTO_INCREMENT,
-    member_id      BIGINT       NOT NULL,               -- FK
+    member_id      BIGINT       NOT NULL,               -- FK → member_user
     address_name   VARCHAR(50)  NOT NULL,               -- 배송지 이름
-    recipient_name VARCHAR(50) NULL,                    -- 배송자 이름
-    phone          VARCHAR(20) NULL,
     zipcode        VARCHAR(10)  NOT NULL,               -- 우편번호
     address        VARCHAR(200) NOT NULL,               -- 'ex) 서울 서초구 고무래로 89
     address_detail VARCHAR(100) NULL,                   -- 'ex) 3003동 303호
@@ -329,7 +337,7 @@ CREATE TABLE terms
     PRIMARY KEY (id),
     UNIQUE KEY uk_terms_version (type, version),
     INDEX          idx_terms_active (type, is_active),
-    CONSTRAINT chk_terms_type CHECK (type IN ('SERVICE', 'PRIVACY', 'LOCATION', 'NOTIFICATION'))
+    CONSTRAINT chk_terms_type CHECK (type IN ('SERVICE', 'PRIVACY', 'LOCATION', 'SERVICE_INFO', 'MARKETING'))
 ) ENGINE=InnoDB COMMENT='약관 버전';
 
 CREATE TABLE member_agreement
@@ -346,6 +354,18 @@ CREATE TABLE member_agreement
     CONSTRAINT fk_agreement_member FOREIGN KEY (member_id) REFERENCES member (id),
     CONSTRAINT fk_agreement_terms FOREIGN KEY (terms_id) REFERENCES terms (id)
 ) ENGINE=InnoDB COMMENT='약관 동의 이력';
+
+CREATE TABLE terms_social_mapping
+(                                        -- 약관과 소셜 로그인 태그 매핑 (카카오 동의 항목 연동)
+    id         BIGINT       NOT NULL AUTO_INCREMENT,
+    terms_id   BIGINT       NOT NULL,    -- FK → terms
+    provider   VARCHAR(20)  NOT NULL,    -- KAKAO, APPLE (SocialProvider)
+    social_tag VARCHAR(100) NOT NULL,    -- 소셜 측 태그 (예: "service_policy", "privacy_policy")
+    created_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    CONSTRAINT fk_tsm_terms FOREIGN KEY (terms_id) REFERENCES terms (id)
+) ENGINE=InnoDB COMMENT='약관-소셜 태그 매핑';
 
 CREATE TABLE member_device
 (                                       -- FCM(Firebase) 디바이스 토큰 -- 데모데이 전까지 절대 개발 금지
@@ -420,6 +440,8 @@ CREATE TABLE photo_lab
     status                    VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
     is_delivery_available     BOOLEAN      NOT NULL DEFAULT FALSE, -- TRUE: 배송가능, FALSE: 배송 불가능
     max_reservations_per_hour INT UNSIGNED NOT NULL DEFAULT 3,     -- 시간당 최대 예약 가능 수 (Owner 조정 가능)
+    load_base_roll            INT UNSIGNED NOT NULL DEFAULT 1,     -- 부하 계산 기준 롤 수
+    load_add_minutes          INT UNSIGNED NOT NULL DEFAULT 120,   -- 추가 롤당 분 (예약 대기 시간 계산)
     qr_code_url               VARCHAR(500) NULL,                   -- QR 코드 이미지 URL (현장 주문용)
     created_at                DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at                DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
@@ -546,11 +568,10 @@ CREATE TABLE region
 CREATE TABLE reservation
 (
     id               BIGINT      NOT NULL AUTO_INCREMENT,
-    member_id        BIGINT      NOT NULL,               -- FK
-    photo_lab_id     BIGINT      NOT NULL,               -- FK
-    reservation_date DATE        NOT NULL,               -- 사용자가 선택한 날짜
-    reservation_time TIME        NOT NULL,               -- 사용자가 선택한 시간
-    status           VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    member_id        BIGINT      NOT NULL,               -- FK → member_user
+    slot_id          BIGINT      NOT NULL,               -- FK → reservation_slot (날짜/시간은 슬롯을 통해 참조)
+    photo_lab_id     BIGINT      NOT NULL,               -- FK → photo_lab
+    status           VARCHAR(20) NOT NULL DEFAULT 'RESERVED',
     -- 작업 내용 선택 (다중 선택 가능)
     is_develop       BOOLEAN     NOT NULL DEFAULT FALSE, -- 현상
     is_scan          BOOLEAN     NOT NULL DEFAULT FALSE, -- 스캔
@@ -561,11 +582,11 @@ CREATE TABLE reservation
     updated_at       DATETIME    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     deleted_at       DATETIME NULL,
     PRIMARY KEY (id),
-    INDEX            idx_reservation_member (member_id, status),
-    INDEX            idx_reservation_lab (photo_lab_id, reservation_date),
+    INDEX            idx_reservation_lab_status (photo_lab_id, status),
     CONSTRAINT fk_reservation_member FOREIGN KEY (member_id) REFERENCES member (id),
+    CONSTRAINT fk_reservation_slot FOREIGN KEY (slot_id) REFERENCES reservation_slot (id),
     CONSTRAINT fk_reservation_lab FOREIGN KEY (photo_lab_id) REFERENCES photo_lab (id),
-    CONSTRAINT chk_reservation_status CHECK (status IN ('PENDING', 'CONFIRMED', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED'))
+    CONSTRAINT chk_reservation_status CHECK (status IN ('RESERVED', 'COMPLETED', 'CANCELED'))
 ) ENGINE=InnoDB COMMENT='예약';
 
 CREATE TABLE reservation_slot
@@ -734,12 +755,14 @@ CREATE TABLE photo_restoration
     id                      BIGINT       NOT NULL AUTO_INCREMENT,
     member_id               BIGINT       NOT NULL,
     original_path           VARCHAR(500) NOT NULL,                   -- 원본 이미지 GCS 경로
-    mask_path               VARCHAR(500) NOT NULL,                   -- 마스크 이미지 GCS 경로 (프론트에서 전송)
+    mask_path               VARCHAR(500) NULL,                       -- 마스크 이미지 GCS 경로 (모델에 따라 불필요)
     restored_path           VARCHAR(500) NULL,                       -- 복원된 이미지 GCS 경로
     restored_width          INT NULL,                                -- 복원된 이미지 너비 (픽셀)
     restored_height         INT NULL,                                -- 복원된 이미지 높이 (픽셀)
     status                  VARCHAR(20)  NOT NULL DEFAULT 'PENDING', -- PENDING, PROCESSING, COMPLETED, FAILED
-    replicate_prediction_id VARCHAR(100) NULL,                       -- Replicate API prediction ID (webhook 매칭용)
+    replicate_prediction_id VARCHAR(100) NULL,                       -- Replicate API prediction ID (하위호환)
+    provider_job_id         VARCHAR(100) NULL,                       -- AI 제공자 작업 ID (범용)
+    provider_name           VARCHAR(30)  NULL,                       -- AI 제공자 이름 (REPLICATE 등)
     -- 크레딧 관련
     credit_used             INT UNSIGNED    NOT NULL DEFAULT 1,      -- 사용된 크레딧 수 (복원 완료 시 차감)
     -- 에러 정보
@@ -767,9 +790,9 @@ CREATE TABLE post
     member_id         BIGINT      NOT NULL,               -- FK
     photo_lab_id      BIGINT NULL,                        -- FK (현상소 이용 시)
     is_self_developed BOOLEAN     NOT NULL DEFAULT FALSE, -- TRUE: 자가현상, FALSE: 현상소 이용
-    title             VARCHAR(200) NULL,
+    title             VARCHAR(30) NOT NULL,               -- 게시글 제목
     content           TEXT        NOT NULL,
-    lab_review        VARCHAR(500) NULL,                  -- 현상소 리뷰 (현상소 이용 시)
+    lab_review        VARCHAR(300) NULL,                  -- 현상소 리뷰 (현상소 이용 시)
     like_count        INT UNSIGNED    NOT NULL DEFAULT 0,
     comment_count     INT UNSIGNED    NOT NULL DEFAULT 0,
     status            VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
@@ -783,7 +806,7 @@ CREATE TABLE post
     FULLTEXT          INDEX ft_post_content (title, content),
     CONSTRAINT fk_post_member FOREIGN KEY (member_id) REFERENCES member (id),
     CONSTRAINT fk_post_lab FOREIGN KEY (photo_lab_id) REFERENCES photo_lab (id),
-    CONSTRAINT chk_post_status CHECK (status IN ('ACTIVE', 'HIDDEN', 'DELETED')),
+    CONSTRAINT chk_post_status CHECK (status IN ('ACTIVE', 'HIDDEN', 'DELETED')), -- CommunityStatus enum
     CONSTRAINT chk_post_lab_required CHECK (
         (is_self_developed = TRUE AND photo_lab_id IS NULL) OR
         (is_self_developed = FALSE AND photo_lab_id IS NOT NULL)
@@ -818,7 +841,7 @@ CREATE TABLE comments
     INDEX      idx_comments_post (post_id, created_at),
     CONSTRAINT fk_comments_post FOREIGN KEY (post_id) REFERENCES post (id),
     CONSTRAINT fk_comments_member FOREIGN KEY (member_id) REFERENCES member (id),
-    CONSTRAINT chk_comments_status CHECK (status IN ('ACTIVE', 'HIDDEN', 'DELETED'))
+    CONSTRAINT chk_comments_status CHECK (status IN ('ACTIVE', 'HIDDEN', 'DELETED')) -- CommunityStatus enum
 ) ENGINE=InnoDB COMMENT='댓글';
 
 CREATE TABLE post_like
@@ -900,7 +923,7 @@ CREATE TABLE inquiry_reply
 -- ============================================
 
 CREATE TABLE notice
-(                                                    -- 전체 회원 공지사항 게시판 
+(                                                    -- 전체 회원 공지사항 게시판 -- ⛔ 데모데이 전 미구현
     id          BIGINT       NOT NULL AUTO_INCREMENT,
     title       VARCHAR(200) NOT NULL,
     content     TEXT         NOT NULL,
@@ -1043,6 +1066,7 @@ CREATE TABLE payment
 | **3.0.2** | **2026-01-23** | photo_lab 테이블 내 review_count 추가, search_history 테이블 신규 생성                                                                                                                                                                                                        |
 | **3.0.3** | **2026-01-25** | region 테이블 칼럼명 변경 sido -> parentRegion, sigungu -> regionName                                                                                                                                                                                                    |
 | **3.1.0** | **2026-02-10** | Token → Credit 용어 리팩토링: `token_history` → `credit_history`, `token_balance` → `credit_balance`, `token_amount` → `credit_amount`, `token_used` → `credit_used`, `TOKEN_PURCHASE` → `CREDIT_PURCHASE` |
+| **3.2.0** | **2026-02-11** | ERD-코드 전면 동기화: `reservation` 구조 변경 (slot_id FK, status: RESERVED/COMPLETED/CANCELED), `reservation_slot` 테이블 목록 추가, `terms_social_mapping` 테이블 신규 추가, `TermsType` CHECK 수정 (SERVICE_INFO/MARKETING), `photo_lab`에 `load_base_roll`/`load_add_minutes` 추가, `photo_restoration`에 `provider_job_id`/`provider_name` 추가 및 `mask_path` nullable 변경, `post.title` VARCHAR(30), `post.lab_review` VARCHAR(300), `member_address`에서 `recipient_name`/`phone` 제거, Enum 정의 코드 기준 전면 정비 (CommunityStatus, CreditRelatedType, FilmType, PrintSize, FrameType, RestorationTier 등), `notice`/`promotion`/`notification`/`member_device` 데모데이 전 미구현 표기 |
 
 ---
 

--- a/src/main/java/com/finders/api/domain/community/service/command/CommentCommandServiceImpl.java
+++ b/src/main/java/com/finders/api/domain/community/service/command/CommentCommandServiceImpl.java
@@ -39,9 +39,7 @@ public class CommentCommandServiceImpl implements CommentCommandService {
 
         Comment savedComment = commentRepository.save(comment);
 
-        String profileUrl = memberUser.getProfileImage() != null
-                ? storageService.getPublicUrl(memberUser.getProfileImage())
-                : null;
+        String profileUrl = storageService.resolveUrl(memberUser.getProfileImage());
 
         return CommentResponse.CommentResDTO.from(savedComment, memberId, profileUrl);
     }

--- a/src/main/java/com/finders/api/domain/community/service/command/PostCommandServiceImpl.java
+++ b/src/main/java/com/finders/api/domain/community/service/command/PostCommandServiceImpl.java
@@ -86,21 +86,10 @@ public class PostCommandServiceImpl implements PostCommandService {
             }
         }
 
-        String profileUrl = resolveImageUrl(memberUser.getProfileImage());
+        String profileUrl = storageService.resolveUrl(memberUser.getProfileImage());
 
         return PostResponse.PostDetailResDTO.fromNewPost(post, profileUrl, imageResDTOs);
     }
-
-    private String resolveImageUrl(String value) {
-        if (value == null || value.isBlank()) return null;
-
-        if (value.startsWith("http://") || value.startsWith("https://")) {
-            return value;
-        }
-
-        return storageService.getPublicUrl(value);
-    }
-
 
     @Override
     public void deletePost(Long postId, Long memberId) {

--- a/src/main/java/com/finders/api/domain/community/service/query/CommentQueryServiceImpl.java
+++ b/src/main/java/com/finders/api/domain/community/service/query/CommentQueryServiceImpl.java
@@ -36,19 +36,9 @@ public class CommentQueryServiceImpl implements CommentQueryService {
         Page<Comment> commentPage = commentRepository.findAllByPostAndStatusOrderByCreatedAtDesc(post, CommunityStatus.ACTIVE, pageRequest);
 
         return commentPage.map(comment -> {
-            String profileUrl = resolveImageUrl(comment.getMemberUser().getProfileImage());
+            String profileUrl = storageService.resolveUrl(comment.getMemberUser().getProfileImage());
             return CommentResponse.CommentResDTO.from(comment, memberId, profileUrl);
         });
-    }
-
-    private String resolveImageUrl(String value) {
-        if (value == null || value.isBlank()) return null;
-
-        if (value.startsWith("http://") || value.startsWith("https://")) {
-            return value;
-        }
-
-        return storageService.getPublicUrl(value);
     }
 
 }

--- a/src/main/java/com/finders/api/domain/community/service/query/PostQueryServiceImpl.java
+++ b/src/main/java/com/finders/api/domain/community/service/query/PostQueryServiceImpl.java
@@ -53,7 +53,7 @@ public class PostQueryServiceImpl implements PostQueryService {
         boolean isLiked = (memberUser != null) && postLikeRepository.existsByPostAndMemberUser(post, memberUser);
         boolean isMine = (memberId != null) && post.getMemberUser().getId().equals(memberId);
 
-        String profileImageUrl = resolveImageUrl(post.getMemberUser().getProfileImage());
+        String profileImageUrl = storageService.resolveUrl(post.getMemberUser().getProfileImage());
 
         List<PostResponse.PostImageResDTO> images = post.getPostImageList().stream()
                 .map(this::toPostImageResDTO)
@@ -118,7 +118,7 @@ public class PostQueryServiceImpl implements PostQueryService {
 
     private PostResponse.PostImageResDTO toPostImageResDTO(com.finders.api.domain.community.entity.PostImage image) {
         if (image == null) return null;
-        return PostResponse.PostImageResDTO.from(image, resolveImageUrl(image.getObjectPath()));
+        return PostResponse.PostImageResDTO.from(image, storageService.resolveUrl(image.getObjectPath()));
     }
 
     private List<PostResponse.PostPreviewDTO> convertToPreviewDTOs(List<Post> posts, Long memberId) {
@@ -142,17 +142,6 @@ public class PostQueryServiceImpl implements PostQueryService {
         List<Long> postIds = posts.stream().map(Post::getId).toList();
         return postLikeRepository.findLikedPostIdsByMemberAndPostIds(memberId, postIds);
     }
-
-    private String resolveImageUrl(String value) {
-        if (value == null || value.isBlank()) return null;
-
-        if (value.startsWith("http://") || value.startsWith("https://")) {
-            return value;
-        }
-
-        return storageService.getPublicUrl(value);
-    }
-
 
     @Override
     public List<String> getAutocompleteSuggestions(String keyword) {

--- a/src/main/java/com/finders/api/domain/member/service/query/MemberQueryServiceImpl.java
+++ b/src/main/java/com/finders/api/domain/member/service/query/MemberQueryServiceImpl.java
@@ -9,6 +9,7 @@ import com.finders.api.domain.member.repository.MemberUserRepository;
 import com.finders.api.domain.member.repository.SocialAccountRepository;
 import com.finders.api.global.exception.CustomException;
 import com.finders.api.global.response.ErrorCode;
+import com.finders.api.infra.storage.StorageService;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.Hibernate;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,7 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     private final MemberRepository memberRepository;
     private final MemberUserRepository memberUserRepository;
     private final SocialAccountRepository socialAccountRepository;
+    private final StorageService storageService;
 
     @Override
     public boolean isNicknameAvailable(String nickname) {
@@ -53,7 +55,7 @@ public class MemberQueryServiceImpl implements MemberQueryService {
 
             userDetail = new MemberResponse.UserDetail(
                     memberUser.getNickname(),
-                    memberUser.getProfileImage(),
+                    storageService.resolveUrl(memberUser.getProfileImage()),
                     memberUser.getCreditBalance(),
                     socialAccounts
             );

--- a/src/main/java/com/finders/api/infra/storage/StorageService.java
+++ b/src/main/java/com/finders/api/infra/storage/StorageService.java
@@ -73,6 +73,28 @@ public interface StorageService {
     String getPublicUrl(String objectPath);
 
     /**
+     * 저장된 값을 클라이언트에 전달 가능한 URL로 변환
+     * <p>
+     * - 이미 완전한 URL(http/https)이면 그대로 반환
+     * - GCS object path이면 Public URL로 변환
+     * - null/blank이면 null 반환
+     * <p>
+     * OAuth 프로필 이미지(외부 URL)와 GCS object path가 혼재하는 컬럼에서 안전하게 사용합니다.
+     *
+     * @param value 외부 URL 또는 GCS object path
+     * @return 접근 가능한 전체 URL, 또는 null
+     */
+    default String resolveUrl(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        if (value.startsWith("http://") || value.startsWith("https://")) {
+            return value;
+        }
+        return getPublicUrl(value);
+    }
+
+    /**
      * 파일 삭제
      *
      * @param objectPath 삭제할 파일 경로


### PR DESCRIPTION
## Summary

카카오 OAuth 프로필 이미지 URL 깨짐 버그 수정 및 dev/local 환경 Redis 컨테이너 안정화

## Changes

### 프로필 이미지 외부 URL 버그 수정
- `StorageService`에 `resolveUrl()` 디폴트 메서드 추가 — 외부 URL(`http://`, `https://`)은 그대로 반환, GCS 경로만 URL 변환
- `CommentCommandServiceImpl`: `getPublicUrl()` → `resolveUrl()` 버그 수정 (카카오 프로필 URL 깨짐)
- `MemberQueryServiceImpl`: `StorageService` 의존성 추가, `resolveUrl()` 적용 (잠재 버그 수정)
- `PostCommandServiceImpl`, `PostQueryServiceImpl`, `CommentQueryServiceImpl`: 중복 `resolveImageUrl()` private 메서드 제거 → 공통 `resolveUrl()`로 통합

### Redis 안정화 (dev/local)
- `docker-compose.yml` (local), `docker-compose.dev.yml` (dev): `redis:latest` → `redis:8.0-alpine` 버전 고정
- Redis 데이터 볼륨 추가 (`redis-data:/data`, `redis-dev-data:/data`) — 재시작 시 데이터 유실 방지
- 메모리 제한 설정 (`--maxmemory 128mb` + Docker `256m`) — OOM kill 방지
- Eviction 정책 추가 (`allkeys-lru`) — 메모리 초과 시 자동 키 정리

### 기타
- `DatabaseSeeder`: 데모데이용 시드 데이터 보강
- `ERD.md`: 스키마 문서 업데이트

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [x] Chore (빌드, 설정 등 기타 변경)

## Related Issues
Closes #430

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [x] dev 서버에 Redis 변경사항 배포 완료 (redis:8.0-alpine 적용 확인)

## Additional Notes
- prod 환경은 Upstash Redis를 사용하므로 Docker Redis 변경 영향 없음
- dev 서버 503 에러 원인: Redis 컨테이너 크래시 → `RedisConnectionFailureException` → 503 반환
  - GCP 로그 및 SSH 진단으로 확인 완료