### PR TITLE
[FIX] GCE에서 Artifact Registry Docker 이미지 pull 인증 추가 (#435)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -123,6 +123,7 @@ jobs:
 
               cd /projects/Finders/BE
               export DOCKER_IMAGE='${{ env.DOCKER_IMAGE }}'
+              sudo gcloud auth configure-docker asia-northeast3-docker.pkg.dev --quiet
               DC='sudo -E docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml'
 
               sudo docker network create finders-network || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,6 +129,7 @@ jobs:
 
               cd /projects/Finders/BE
               export DOCKER_IMAGE='${{ env.DOCKER_IMAGE }}'
+              sudo gcloud auth configure-docker asia-northeast3-docker.pkg.dev --quiet
               DC='sudo -E docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml'
 
               sudo docker network create finders-network || true


### PR DESCRIPTION
## Summary
GCE 서버에서 Artifact Registry의 Docker 이미지를 pull할 때 인증 실패(`Unauthenticated request`) 문제를 해결합니다.

## Changes
- `deploy-dev.yml`: GCE 배포 시 `sudo gcloud auth configure-docker asia-northeast3-docker.pkg.dev --quiet` 추가
- `deploy.yml`: 운영 배포에도 동일 인증 설정 추가

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
Closes #435

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes
- PR #436 merge 후, Docker 이미지 소스가 Docker Hub → Artifact Registry로 변경되었으나 GCE에서 AR pull 시 인증이 누락되어 배포 실패
- `gcloud auth configure-docker`로 Docker credential helper를 설정하면 AR에서 이미지를 정상적으로 pull 가능
- GCE SA(`517500643080-compute@developer.gserviceaccount.com`)는 이미 `roles/artifactregistry.writer` 권한 보유