### PR TITLE
[FIX] GCE에서 Artifact Registry Docker 인증 방식 변경

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -123,7 +123,7 @@ jobs:
 
               cd /projects/Finders/BE
               export DOCKER_IMAGE='${{ env.DOCKER_IMAGE }}'
-              sudo gcloud auth configure-docker asia-northeast3-docker.pkg.dev --quiet
+              gcloud auth print-access-token | sudo docker login -u oauth2accesstoken --password-stdin https://asia-northeast3-docker.pkg.dev
               DC='sudo -E docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml'
 
               sudo docker network create finders-network || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,7 +129,7 @@ jobs:
 
               cd /projects/Finders/BE
               export DOCKER_IMAGE='${{ env.DOCKER_IMAGE }}'
-              sudo gcloud auth configure-docker asia-northeast3-docker.pkg.dev --quiet
+              gcloud auth print-access-token | sudo docker login -u oauth2accesstoken --password-stdin https://asia-northeast3-docker.pkg.dev
               DC='sudo -E docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml'
 
               sudo docker network create finders-network || true


### PR DESCRIPTION
## Summary
GCE에서 Artifact Registry 이미지 pull 시 `Unauthenticated request` 오류를 해결합니다.

`sudo gcloud auth configure-docker`는 credential helper만 등록하고, sudo 환경에서 Docker → credential helper → gcloud 체인이 동작하지 않아 인증이 실패했습니다. access token을 직접 docker login에 전달하는 방식으로 변경합니다.

## Changes
- `deploy-dev.yml`: `sudo gcloud auth configure-docker` → `gcloud auth print-access-token | sudo docker login` 방식으로 변경
- `deploy.yml`: 동일 변경 (운영 배포)

### 기존 (credential helper - 동작 안 함)
```bash
sudo gcloud auth configure-docker asia-northeast3-docker.pkg.dev --quiet
# → /root/.docker/config.json에 credHelper 등록
# → sudo 환경에서 docker-credential-gcloud가 토큰을 못 가져옴
```

### 변경 (access token 직접 전달)
```bash
gcloud auth print-access-token | sudo docker login -u oauth2accesstoken --password-stdin https://asia-northeast3-docker.pkg.dev
# → GCE 메타데이터 서버에서 SA 토큰 발급
# → /root/.docker/config.json에 실제 토큰 저장
# → 별도 credential 불필요 (GCE SA가 AR writer 권한 보유)
```

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
Closes #435

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes
- `oauth2accesstoken`은 Google이 AR 인증용으로 정한 고정 유저명 (실제 계정 아님)
- GCE SA(`517500643080-compute@developer.gserviceaccount.com`)가 `roles/artifactregistry.writer` 보유
- access token은 60분 수명이지만, 배포 시 pull 한 번만 하면 되므로 충분