### PR TITLE
[FIX] docker login에서 sudo 제거 — HOME 경로 불일치로 AR 인증 실패

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -123,7 +123,7 @@ jobs:
 
               cd /projects/Finders/BE
               export DOCKER_IMAGE='${{ env.DOCKER_IMAGE }}'
-              gcloud auth print-access-token | sudo docker login -u oauth2accesstoken --password-stdin https://asia-northeast3-docker.pkg.dev
+              gcloud auth print-access-token | docker login -u oauth2accesstoken --password-stdin https://asia-northeast3-docker.pkg.dev
               DC='sudo -E docker compose --env-file .env.dev -f docker-compose.infra.yml -f docker-compose.dev.yml'
 
               sudo docker network create finders-network || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,7 +129,7 @@ jobs:
 
               cd /projects/Finders/BE
               export DOCKER_IMAGE='${{ env.DOCKER_IMAGE }}'
-              gcloud auth print-access-token | sudo docker login -u oauth2accesstoken --password-stdin https://asia-northeast3-docker.pkg.dev
+              gcloud auth print-access-token | docker login -u oauth2accesstoken --password-stdin https://asia-northeast3-docker.pkg.dev
               DC='sudo -E docker compose --env-file .env.prod -f docker-compose.infra.yml -f docker-compose.prod.yml'
 
               sudo docker network create finders-network || true


### PR DESCRIPTION
## Summary
GCE 배포 시 Artifact Registry 이미지 pull에서 `Unauthenticated request` 오류가 발생하는 문제를 해결합니다.

## Changes
- `deploy-dev.yml`: `sudo docker login` → `docker login` (sudo 제거)
- `deploy.yml`: 동일 변경 (운영 배포)

## 근본 원인

`docker login`과 `docker compose`가 **서로 다른 HOME 경로**의 config.json을 참조하고 있었습니다.

| 명령어 | HOME | config.json 위치 |
|--------|------|-----------------|
| `sudo docker login` | `/root` (sudo 기본) | `/root/.docker/config.json`에 **저장** |
| `sudo -E docker compose pull` | `/home/sa_xxx` (-E가 SSH유저 HOME 보존) | `/home/sa_xxx/.docker/config.json`에서 **읽기** → 없음! |

`sudo` 제거 시:

| 명령어 | HOME | config.json 위치 |
|--------|------|-----------------|
| `docker login` | `/home/sa_xxx` (SSH 유저) | `/home/sa_xxx/.docker/config.json`에 **저장** |
| `sudo -E docker compose pull` | `/home/sa_xxx` (-E가 HOME 보존) | `/home/sa_xxx/.docker/config.json`에서 **읽기** → 인증 성공 |

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
Closes #435

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes
- PR #438에서 `sudo gcloud auth configure-docker` → `gcloud auth print-access-token | sudo docker login` 으로 변경 → `Login Succeeded` 뜨지만 여전히 pull 실패
- 원인: `sudo`가 HOME을 `/root`로 바꾸는데, `sudo -E`는 SSH 유저의 HOME을 보존 → 저장/읽기 경로 불일치
- `docker login`은 Docker 데몬이 아닌 클라이언트 명령이라 sudo 불필요