### PR TITLE
[FIX] Restoration API 버그 수정 - Sort 파싱 및 SUPIR input 타입 (#441)

### DIFF
--- a/src/main/java/com/finders/api/domain/photo/controller/PhotoRestorationController.java
+++ b/src/main/java/com/finders/api/domain/photo/controller/PhotoRestorationController.java
@@ -7,12 +7,14 @@ import com.finders.api.domain.photo.service.command.PhotoRestorationCommandServi
 import com.finders.api.domain.photo.service.command.PhotoRestorationShareService;
 import com.finders.api.domain.photo.service.query.PhotoRestorationQueryService;
 import com.finders.api.global.response.ApiResponse;
+import com.finders.api.global.response.PagedResponse;
 import com.finders.api.global.response.SuccessCode;
 import com.finders.api.global.security.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -108,12 +110,12 @@ public class PhotoRestorationController {
                 """
     )
     @GetMapping
-    public ApiResponse<Page<RestorationResponse.Summary>> getRestorationHistory(
+    public PagedResponse<RestorationResponse.Summary> getRestorationHistory(
             @AuthenticationPrincipal AuthUser user,
-            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         Page<RestorationResponse.Summary> response = queryService.getRestorationHistory(user.memberId(), pageable);
-        return ApiResponse.ok(response);
+        return PagedResponse.of(SuccessCode.OK, response);
     }
 
     @Operation(summary = "복원 결과 피드백", description = "복원 결과에 대한 피드백(좋음/나쁨)을 남깁니다.")

--- a/src/main/java/com/finders/api/domain/photo/controller/PhotoRestorationController.java
+++ b/src/main/java/com/finders/api/domain/photo/controller/PhotoRestorationController.java
@@ -14,17 +14,15 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.http.HttpStatus;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
-import java.util.Arrays;
 
 /**
  * 사진 복원 API 컨트롤러
@@ -112,31 +110,10 @@ public class PhotoRestorationController {
     @GetMapping
     public ApiResponse<Page<RestorationResponse.Summary>> getRestorationHistory(
             @AuthenticationPrincipal AuthUser user,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "createdAt,desc") String[] sort
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by(parseSortOrders(sort)));
         Page<RestorationResponse.Summary> response = queryService.getRestorationHistory(user.memberId(), pageable);
         return ApiResponse.ok(response);
-    }
-
-    /**
-     * 정렬 파라미터 파싱
-     * <p>
-     * "createdAt,desc" 형식의 문자열을 Sort.Order로 변환
-     */
-    private Sort.Order[] parseSortOrders(String[] sortParams) {
-        return Arrays.stream(sortParams)
-                .map(param -> {
-                    String[] parts = param.split(",");
-                    String property = parts[0];
-                    Sort.Direction direction = parts.length > 1 && "asc".equalsIgnoreCase(parts[1])
-                            ? Sort.Direction.ASC
-                            : Sort.Direction.DESC;
-                    return new Sort.Order(direction, property);
-                })
-                .toArray(Sort.Order[]::new);
     }
 
     @Operation(summary = "복원 결과 피드백", description = "복원 결과에 대한 피드백(좋음/나쁨)을 남깁니다.")

--- a/src/main/java/com/finders/api/infra/replicate/SupirInput.java
+++ b/src/main/java/com/finders/api/infra/replicate/SupirInput.java
@@ -18,7 +18,7 @@ public record SupirInput(
         @JsonProperty("n_prompt")
         String nPrompt,
         @JsonProperty("s_stage1")
-        Double sStage1,
+        Integer sStage1,
         @JsonProperty("s_stage2")
         Double sStage2,
         @JsonProperty("edm_steps")
@@ -31,7 +31,7 @@ public record SupirInput(
     private static final Integer DEFAULT_UPSCALE = 2;
     private static final String DEFAULT_A_PROMPT = "high quality, detailed, restored analog film photograph, sharp focus, natural colors";
     private static final String DEFAULT_N_PROMPT = "blur, noise, artifacts, distortion, oversaturated, overprocessed";
-    private static final Double DEFAULT_S_STAGE1 = 0.9;
+    private static final Integer DEFAULT_S_STAGE1 = -1;
     private static final Double DEFAULT_S_STAGE2 = 0.2;
     private static final Integer DEFAULT_EDM_STEPS = 50;
     private static final String DEFAULT_COLOR_FIX = "AdaIn";


### PR DESCRIPTION
## Summary
GET /restorations 500 에러(Sort 파라미터 파싱 버그)와 POST /restorations 422 에러(SUPIR 모델 input 타입 불일치)를 수정합니다.

## Changes
- **GET /restorations Sort 파싱 버그 수정**: 수동 `@RequestParam String[] sort` + `parseSortOrders()` 방식에서 Spring Data의 `@PageableDefault`로 교체. Spring이 `String[]`에 대해 콤마를 배열 구분자로 해석하여 `"desc"`를 프로퍼티명으로 인식하던 문제(`PropertyReferenceException`) 해결.
- **POST /restorations SUPIR 모델 422 에러 수정**: `SupirInput.s_stage1` 필드 타입을 `Double` → `Integer`로 변경. Replicate SUPIR 모델(`cjwbw/supir-v0q`)이 `s_stage1`에 integer 타입을 요구하는데 `Double`(0.9)을 보내 422 UNPROCESSABLE_ENTITY 발생하던 문제 해결. 기본값을 모델 기본값(-1, "negative means invalid")으로 변경.

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
Fixes #441

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [x] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes
- **GET /restorations**: `?page=0&size=10&sort=createdAt,desc` 형태의 요청이 Spring Data의 `PageableHandlerMethodArgumentResolver`에 의해 정상 처리됩니다. 기존 FE 요청 형식 변경 불필요.
- **POST /restorations**: SUPIR 모델의 `s_stage1` 기본값 -1은 "Stage1 컨트롤 비활성화"를 의미하며, 모델이 자체 기본 동작을 수행합니다. 배포 후 Replicate 호출 정상 동작 확인 필요.
- **에러 원인 확인 방법**: dev 서버 docker 로그에서 `[ReplicateClient.handleError] Error response: status=422, body={...input.s_stage1: Invalid type. Expected: integer, given: number...}` 로 확인됨.