### PR TITLE
[FIX] 복원 이력 조회 Sort 파싱 오류 수정 (#441)

### DIFF
--- a/src/main/java/com/finders/api/domain/photo/controller/PhotoRestorationController.java
+++ b/src/main/java/com/finders/api/domain/photo/controller/PhotoRestorationController.java
@@ -11,14 +11,13 @@ import com.finders.api.global.response.PagedResponse;
 import com.finders.api.global.response.SuccessCode;
 import com.finders.api.global.security.AuthUser;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -112,8 +111,10 @@ public class PhotoRestorationController {
     @GetMapping
     public PagedResponse<RestorationResponse.Summary> getRestorationHistory(
             @AuthenticationPrincipal AuthUser user,
-            @ParameterObject @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "10") int size
     ) {
+        PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<RestorationResponse.Summary> response = queryService.getRestorationHistory(user.memberId(), pageable);
         return PagedResponse.of(SuccessCode.OK, response);
     }

--- a/src/main/java/com/finders/api/domain/photo/controller/PhotoRestorationController.java
+++ b/src/main/java/com/finders/api/domain/photo/controller/PhotoRestorationController.java
@@ -98,7 +98,7 @@ public class PhotoRestorationController {
                 ### 파라미터
                 - page: 페이지 번호 (0부터 시작, 기본값: 0)
                 - size: 페이지 크기 (기본값: 10)
-                - sort: 정렬 기준 (기본값: createdAt,desc)
+                - 정렬: 최신순 고정 (createdAt DESC)
 
                 ### 응답
                 - content: 복원 이력 목록
@@ -116,7 +116,7 @@ public class PhotoRestorationController {
     ) {
         PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         Page<RestorationResponse.Summary> response = queryService.getRestorationHistory(user.memberId(), pageable);
-        return PagedResponse.of(SuccessCode.OK, response);
+        return PagedResponse.of(SuccessCode.RESTORATION_HISTORY_FOUND, response);
     }
 
     @Operation(summary = "복원 결과 피드백", description = "복원 결과에 대한 피드백(좋음/나쁨)을 남깁니다.")

--- a/src/main/java/com/finders/api/global/response/SuccessCode.java
+++ b/src/main/java/com/finders/api/global/response/SuccessCode.java
@@ -68,6 +68,7 @@ public enum SuccessCode implements BaseCode {
     // ========================================
     RESTORATION_CREATED(HttpStatus.ACCEPTED, "RESTORATION_201", "복원 요청이 생성되었습니다."),
     RESTORATION_FOUND(HttpStatus.OK, "RESTORATION_200", "복원 결과 조회에 성공했습니다."),
+    RESTORATION_HISTORY_FOUND(HttpStatus.OK, "RESTORATION_200", "복원 이력 조회에 성공했습니다."),
 
     // ========================================
     // Credit


### PR DESCRIPTION
## Summary
`GET /restorations` 호출 시 500 에러(PropertyReferenceException: No property 'desc') 발생하는 문제 수정

## Changes
- `@ParameterObject` + `@PageableDefault` 어노테이션 조합 제거
- 명시적 `@RequestParam(page, size)` + `PageRequest.of()` 방식으로 변경
- Sort를 컨트롤러에서 직접 생성하여 `desc`가 프로퍼티로 파싱되는 문제 해결

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)

## Related Issues
Fixes #441

## Root Cause
SpringDoc의 `@ParameterObject`와 Spring Data의 `@PageableDefault(sort, direction)` 조합 시,
sort 파라미터가 `"createdAt,desc"` 단일 문자열로 전달되면서 Spring이 `desc`를 엔티티 프로퍼티명으로 해석.
PostController 등 다른 컨트롤러는 Pageable의 Sort를 실제 JPA 쿼리에 사용하지 않아 문제가 없었으나,
PhotoRestorationController만 Pageable을 Spring Data JPA에 직접 전달하여 문제 발생.

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [x] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes
- FE 변경 없음 (기존 page/size 쿼리 파라미터 동일하게 사용)
- 정렬은 `createdAt DESC` 고정 (FE에서 sort 파라미터 사용하지 않음)