### PR TITLE
[FIX] Blue-Green 배포 시 Docker Compose profiled 서비스 이미지 pull 누락 수정 (#444)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -150,7 +150,7 @@ jobs:
                 sleep 10
               fi
 
-              \$DC pull
+              \$DC --profile blue --profile green pull
               echo \"Green 슬롯(dev-\$GREEN_SLOT) 시작...\"
               \$DC --profile \$GREEN_SLOT up -d
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -155,7 +155,7 @@ jobs:
                 sleep 10
               fi
 
-              \$DC pull
+              \$DC --profile blue --profile green pull
               echo \"Green 슬롯(prod-\$GREEN_SLOT) 시작\"
               \$DC --profile \$GREEN_SLOT up -d
 


### PR DESCRIPTION
## Summary
Blue-Green 배포 CD 워크플로우에서 `$DC pull`이 Docker Compose profile이 지정된 API 서비스(dev-blue/dev-green, prod-blue/prod-green)의 이미지를 pull하지 않아, GCE에서 구버전 이미지로 컨테이너가 생성되던 버그를 수정합니다.

## Changes
- `deploy-dev.yml`: `$DC pull` → `$DC --profile blue --profile green pull`
- `deploy.yml`: `$DC pull` → `$DC --profile blue --profile green pull`

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)

## Related Issues
Closes #444

## Root Cause
Docker Compose는 `--profile` 플래그 없이 `pull`을 실행하면 **프로파일이 없는 서비스만** pull합니다.
- ✅ pull 됨: `redis`, `traefik`, `cloudflared` (프로파일 없음)
- ❌ skip 됨: `dev-blue`, `dev-green`, `prod-blue`, `prod-green` (프로파일 있음)

CD 로그 증거 (run #21891784829):
```
Image redis:8.0-alpine Pulling
Image traefik:v3 Pulling  
Image cloudflare/cloudflared:latest Pulling
→ API 이미지 pull 로그 없음!
```

AR digest vs GCE container digest 불일치:
- AR (최신): `sha256:06aad4de...`
- GCE (실행중): `sha256:c6e82b5c...`

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] ~~새로운 기능에 대한 테스트를 작성했습니다~~ (CI/CD 워크플로우 변경, 배포로 검증)
- [ ] ~~API 변경이 있다면 Swagger 문서가 업데이트 되었습니다~~ (해당 없음)

## Additional Notes
- 이 PR이 머지되면 CD가 트리거되어 즉시 검증 가능합니다 (최신 이미지가 GCE에 pull되는지 확인)
- dev와 prod 양쪽 워크플로우 모두 동일하게 수정했습니다