### PR TITLE
[FIX] Replicate Webhook SUPIR 모델 output 파싱 실패 수정 (#441)

### DIFF
--- a/src/main/java/com/finders/api/infra/replicate/ReplicateResponse.java
+++ b/src/main/java/com/finders/api/infra/replicate/ReplicateResponse.java
@@ -12,12 +12,18 @@ public class ReplicateResponse {
 
     /**
      * Prediction 응답 (API 응답 및 Webhook 페이로드 공용)
+     * <p>
+     * output 필드는 모델에 따라 형식이 다릅니다:
+     * - List&lt;String&gt;: flux-kontext-apps 등 (예: ["url1", "url2"])
+     * - String: cjwbw/supir-v0q 등 (예: "https://...")
+     * <p>
+     * Object로 받아 getFirstOutput()에서 타입에 따라 분기 처리합니다.
      */
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record Prediction(
             String id,
             String status,
-            List<String> output,
+            Object output,
             String error,
             @JsonProperty("created_at")
             String createdAt
@@ -34,11 +40,29 @@ public class ReplicateResponse {
             return "failed".equals(status);
         }
 
+        /**
+         * 첫 번째 output URL을 반환합니다.
+         * <p>
+         * 모델별 output 형식 차이를 처리합니다:
+         * - String 타입: 해당 값을 그대로 반환
+         * - List 타입: 첫 번째 요소를 반환
+         */
+        @SuppressWarnings("unchecked")
         public String getFirstOutput() {
-            if (output == null || output.isEmpty()) {
+            if (output == null) {
                 return null;
             }
-            return output.get(0);
+            if (output instanceof String s) {
+                return s;
+            }
+            if (output instanceof List<?> list) {
+                if (list.isEmpty()) {
+                    return null;
+                }
+                Object first = list.getFirst();
+                return first != null ? first.toString() : null;
+            }
+            return output.toString();
         }
     }
 }


### PR DESCRIPTION
## Summary
Replicate Webhook에서 SUPIR 모델(`cjwbw/supir-v0q`)의 output을 파싱하지 못해 복원 완료 콜백이 400으로 거부되던 버그를 수정합니다.

## Changes
- `ReplicateResponse.Prediction.output`: `List<String>` → `Object` (모델별 다형 타입 지원)
- `getFirstOutput()`: `String` / `List` 타입 분기 처리 추가

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)

## Related Issues
Closes #441

## Root Cause
| 모델 | output 형식 |
|------|------------|
| flux-kontext-apps (이전) | `List<String>` — `["url1", "url2"]` |
| **cjwbw/supir-v0q (현재)** | **`String`** — `"https://..."` |

기존 DTO는 `List<String> output`으로 정의되어 있어서, SUPIR의 단일 String output을 Jackson이 파싱 실패 → `IOException` → 400 응답.

Replicate webhook 로그:
```
prediction.succeeded → Status 400
{"code":"COMMON_400","message":"잘못된 Webhook 페이로드 형식입니다."}
```

Replicate API로 확인한 SUPIR 실제 output:
```json
{
  "output": "https://replicate.delivery/xezq/.../out.png",
  "output_type": "string"
}
```

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] ~~새로운 기능에 대한 테스트를 작성했습니다~~ (배포 후 실제 복원 요청으로 검증)
- [ ] ~~API 변경이 있다면 Swagger 문서가 업데이트 되었습니다~~ (해당 없음)

## Additional Notes
- 이 PR 머지 후 `POST /restorations`로 새 복원 요청 → Webhook 콜백 성공 → 복원 COMPLETED 까지 E2E 검증 필요
- `Object` 타입으로 받되 `@JsonIgnoreProperties(ignoreUnknown = true)`와 조합하여 안전하게 처리