### PR TITLE
[HOTFIX] 프로필 이미지 저장 방식 GCS 이관 및 닉네임 유효성 검사 완화 (#456)

### DIFF
--- a/src/main/java/com/finders/api/domain/member/dto/request/MemberRequest.java
+++ b/src/main/java/com/finders/api/domain/member/dto/request/MemberRequest.java
@@ -11,7 +11,7 @@ public class MemberRequest {
     public record SocialSignupComplete(
             @Schema(description = "닉네임 (2~8자, 한글/영문/숫자)", example = "파인더")
             @NotBlank(message = "닉네임은 필수입니다.") @Pattern(
-                    regexp = "^[가-힣a-zA-Z0-9]{2,8}$",
+                    regexp = "^[가-힣ㄱ-ㅎㅏ-ㅣa-zA-Z0-9]{2,8}$",
                     message = "닉네임은 2~8자의 한글, 영문, 숫자로만 구성되어야 합니다.")
             String nickname,
 


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
<!-- 변경 사항을 간단히 설명해주세요 -->
소셜 로그인 시 외부(카카오) 프로필 이미지 URL을 그대로 저장하던 방식에서, 서버 측에서 이미지를 직접 다운로드하여 GCS(Google Cloud Storage)로 이관 후 저장하는 방식으로 변경했습니다. 또한, 닉네임 정규식을 수정하여 사용자 편의성을 높였습니다.

## Changes
<!-- 변경된 내용을 목록으로 작성해주세요 -->
- 프로필 이미지 저장 아키텍처 개선
  - WebClient를 사용하여 카카오 프로필 이미지를 서버로 다운로드하는 로직 구현
  - StorageService를 통해 GCS 버킷 내 유저별 고유 경로(profiles/{memberId}/...)로 업로드
  - DB에는 Full URL이 아닌 objectPath를 저장하여 유지보수성 향상

- 닉네임 정규식(Validation) 수정
  - 기존: 완성형 한글만 허용 (가-힣)
  - 변경: 자음 및 모음 혼용 허용 (가-힣ㄱ-ㅎㅏ-ㅣ)하여 'ㅋㅋ', '올ㄹㅇㅇ' 등 자유로운 닉네임 설정 가능


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [x] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->

Closes #456 

## Checklist
<!-- PR 제출 전 확인사항 -->
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다


## Screenshots (Optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->


## Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

