### PR TITLE
[REFACTOR] 로그아웃, 토큰 재발급 Member 대상으로 확장 및 탈퇴 회원 방어 로직 추가 (#475)

### DIFF
--- a/src/main/java/com/finders/api/domain/member/service/query/MemberQueryServiceImpl.java
+++ b/src/main/java/com/finders/api/domain/member/service/query/MemberQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.finders.api.domain.member.service.query;
 import com.finders.api.domain.member.dto.response.MemberResponse;
 import com.finders.api.domain.member.entity.Member;
 import com.finders.api.domain.member.entity.MemberUser;
+import com.finders.api.domain.member.enums.MemberStatus;
 import com.finders.api.domain.terms.repository.MemberAgreementRepository;
 import com.finders.api.domain.member.repository.MemberRepository;
 import com.finders.api.domain.member.repository.MemberUserRepository;
@@ -35,6 +36,11 @@ public class MemberQueryServiceImpl implements MemberQueryService {
     public MemberResponse.MyProfile getMyProfile(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+        if (member.getStatus() != MemberStatus.ACTIVE) {
+            throw new CustomException(ErrorCode.MEMBER_INACTIVE);
+        }
+
         return convertToMyProfileDTO(member);
     }
 


### PR DESCRIPTION
<!--
## PR 제목 컨벤션
[TYPE] 설명 (#이슈번호)

예시:
- [FEAT] 회원가입 API 구현 (#14)
- [FIX] 이미지 업로드 시 NPE 수정 (#23)
- [REFACTOR] 토큰 로직 분리 (#8)
- [DOCS] ERD 스키마 업데이트 (#6)
- [CHORE] CI/CD 파이프라인 추가 (#3)
- [RELEASE] v1.0.0 배포 (#30)

TYPE: FEAT, FIX, DOCS, REFACTOR, TEST, CHORE, RENAME, REMOVE, RELEASE
-->

## Summary
<!-- 변경 사항을 간단히 설명해주세요 -->
일반 사용자(User)에게 국한되었던 토큰 재발급 및 로그아웃 로직을 모든 회원(Member)이 공통으로 사용할 수 있도록 확장하였고, 탈퇴한 회원의 경우 프로필 조회가 불가능하도록 수정하였습니다.

## Changes
<!-- 변경된 내용을 목록으로 작성해주세요 -->
- 도메인 확장: AuthService 내 reissueToken, logout 로직의 대상을 MemberUser 엔티티로 통합하여 사장님(Owner) 권한도 처리 가능하도록 리팩토링했습니다.
- 탈퇴한 회원의 경우 내 페이지 조회가 불가능하도록 수정하였습니다.


## Type of Change
<!-- 해당하는 항목에 x 표시해주세요 -->
- [ ] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [x] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)


## Related Issues
<!-- 관련 이슈 번호를 작성해주세요 (예: Closes #123, Fixes #456) -->
Closes #475 

## Checklist
<!-- PR 제출 전 확인사항 -->
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다


## Screenshots (Optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->


## Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

