### PR TITLE
[FIX] Cloud Logging 비용 폭증 원인 수정 (#481)

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -56,9 +56,10 @@ services:
       - "traefik.http.routers.dev.rule=Host(`dev-api.finders.it.kr`)"
       - "traefik.http.services.dev.loadbalancer.server.port=8080"
     logging:
-      driver: "gcplogs"
+      driver: "json-file"
       options:
-        labels: "app=finders-dev-api,env=dev,slot=blue"
+        max-size: "10m"
+        max-file: "3"
     profiles:
       - blue
     networks:
@@ -91,9 +92,10 @@ services:
       - "traefik.http.routers.dev.rule=Host(`dev-api.finders.it.kr`)"
       - "traefik.http.services.dev.loadbalancer.server.port=8080"
     logging:
-      driver: "gcplogs"
+      driver: "json-file"
       options:
-        labels: "app=finders-dev-api,env=dev,slot=green"
+        max-size: "10m"
+        max-file: "3"
     profiles:
       - green
     networks:

--- a/docs/architecture/INFRASTRUCTURE.md
+++ b/docs/architecture/INFRASTRUCTURE.md
@@ -239,7 +239,7 @@ GCE 인스턴스에 외부 IP가 없으므로, Docker 이미지 pull 등 **Googl
 | VPC/서브넷 | `finders-vpc` / `private-app-subnet` |
 | 네트워크 태그 | `api-server`, `http-server`, `https-server` |
 | 서비스 계정 | `compute-sa` |
-| 로깅 | Docker `gcplogs` 드라이버 → Cloud Logging |
+| 로깅 | Prod: Docker `gcplogs` → Cloud Logging / Dev: `json-file` 로컬 저장 |
 
 ### GCE 내 Docker 컨테이너 구성
 
@@ -453,7 +453,7 @@ GCS에 업로드된 이미지를 리사이징하는 서버리스 서비스입니
 
 | 서비스 | 용도 |
 |--------|------|
-| **Cloud Logging** | Docker 컨테이너 로그 (`gcplogs` 드라이버로 자동 전송) |
+| **Cloud Logging** | Prod 컨테이너 로그 (`gcplogs` 드라이버로 자동 전송, Dev는 `json-file` 로컬 저장) |
 | **Cloud Monitoring** | 커스텀 대시보드 (Terraform 관리) |
 
 ---

--- a/docs/infra/GCP_LOGGING_GUIDE.md
+++ b/docs/infra/GCP_LOGGING_GUIDE.md
@@ -25,9 +25,9 @@
 ## 로그 조회 방법
 
 ### 로그 구조
-- **Cloud Logging Logback Appender** 사용
-- **Structured JSON** 형식으로 전송 (로그 레벨 → Severity 자동 매핑)
-- **logback-spring.xml** 설정 기반
+- **Docker `gcplogs` 드라이버**를 통해 Cloud Logging으로 전송 (prod 환경만 해당)
+- **dev 환경**은 `json-file` 드라이버를 사용하여 로컬 저장 (Cloud Logging 비용 방지)
+- **logback-spring.xml** 설정 기반으로 로그 레벨 제어
 
 ### 기본 필터 사용
 
@@ -91,10 +91,16 @@ jsonPayload.logger_name=~"com.finders.api"
 - 네트워크 트래픽
 - 디스크 I/O
 
-### 로깅 방식 변경에 따른 안내
-- 현재 docker-compose.prod.yml에 gcplogs 드라이버가 설정되어 있습니다. 
-- 이 설정이 활성화되면 서버 터미널에서 docker logs -f 명령어를 입력해도 로그가 출력되지 않습니다. 
-- 실시간 로그 확인은 반드시 GCP 로그 탐색기를 이용해 주세요.
+### 환경별 로깅 방식
+
+| 환경 | Docker 로그 드라이버 | 로그 확인 방법 |
+|------|---------------------|----------------|
+| **Prod** | `gcplogs` → Cloud Logging | GCP 로그 탐색기 (아래 필터 사용) |
+| **Dev** | `json-file` (로컬 저장) | `docker logs -f <컨테이너>` |
+| **Local** | Docker 기본 (stdout) | 터미널 콘솔 출력 |
+
+- **Prod**: `docker logs -f` 명령어가 동작하지 않습니다. 반드시 GCP 로그 탐색기를 이용해 주세요.
+- **Dev**: Cloud Logging으로 전송되지 않습니다. SSH 접속 후 `docker logs -f`로 확인하세요.
 
 ## 참고 링크
 

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -30,13 +30,10 @@ jwt:
   refresh-token-expiry: 604800000  # 7일
 
 # ========================================
-# Logging (비용 절감 - Cloud Logging 과금 방지)
+# Logging (base와 다른 부분만 override)
 # ========================================
 logging:
   level:
-    root: INFO
-    com.finders: DEBUG
-    org.springframework.web: INFO
     org.hibernate.SQL: WARN
     org.hibernate.orm.jdbc.bind: WARN
     org.springframework.data.redis: WARN

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -35,7 +35,7 @@ jwt:
 logging:
   level:
     root: INFO
-    com.finders: INFO
+    com.finders: DEBUG
     org.springframework.web: INFO
     org.hibernate.SQL: WARN
     org.hibernate.orm.jdbc.bind: WARN

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -30,16 +30,17 @@ jwt:
   refresh-token-expiry: 604800000  # 7일
 
 # ========================================
-# Logging (상세)
+# Logging (비용 절감 - Cloud Logging 과금 방지)
 # ========================================
 logging:
   level:
     root: INFO
-    com.finders: DEBUG
+    com.finders: INFO
     org.springframework.web: INFO
-    org.hibernate.SQL: DEBUG
-    org.springframework.data.redis: DEBUG
-    io.lettuce.core: DEBUG
+    org.hibernate.SQL: WARN
+    org.hibernate.orm.jdbc.bind: WARN
+    org.springframework.data.redis: WARN
+    io.lettuce.core: WARN
 
 # ========================================
 # Actuator (개발용 노출)

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -30,6 +30,7 @@ logging:
     root: WARN
     com.finders: INFO
     org.springframework.web: WARN
+    org.hibernate: WARN
 
 # ========================================
 # Actuator (제한적 노출)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -183,7 +183,7 @@ discord:
 logging:
   level:
     root: INFO
-    com.finders: INFO
+    com.finders: DEBUG
 
 # ========================================
 # CORS 설정

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,7 +34,7 @@ spring:
     open-in-view: false
     properties:
       hibernate:
-        format_sql: true
+        format_sql: false
         default_batch_fetch_size: 100
 
   # ========================================
@@ -183,7 +183,7 @@ discord:
 logging:
   level:
     root: INFO
-    com.finders: DEBUG
+    com.finders: INFO
 
 # ========================================
 # CORS 설정

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -48,7 +48,7 @@
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>
-        <logger name="com.finders" level="INFO"/>
+        <logger name="com.finders" level="DEBUG"/>
         <logger name="org.springframework.web" level="INFO"/>
         <logger name="org.hibernate.SQL" level="WARN"/>
         <logger name="org.hibernate.orm.jdbc.bind" level="WARN"/>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -8,7 +8,8 @@
 
     <!-- ========================================
          Console Appender
-         - Docker gcplogs 드라이버가 GCP Cloud Logging으로 전송
+         - prod: Docker gcplogs 드라이버가 GCP Cloud Logging으로 전송
+         - dev: Docker json-file 드라이버로 로컬 저장
          ======================================== -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -18,19 +18,18 @@
     </appender>
 
     <!-- ========================================
-         로컬 프로필: 콘솔 출력 (상세)
+         로컬 프로필
+         로그 레벨은 application-local.yml에서 관리
          ======================================== -->
     <springProfile name="local">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>
-        <logger name="com.finders" level="DEBUG"/>
-        <logger name="org.hibernate.SQL" level="DEBUG"/>
-        <logger name="org.hibernate.orm.jdbc.bind" level="TRACE"/>
     </springProfile>
 
     <!-- ========================================
-         테스트 프로필: 콘솔 출력 (간소화)
+         테스트 프로필
+         test 전용 application.yml에 logging 설정이 없으므로 여기서 관리
          ======================================== -->
     <springProfile name="test">
         <root level="WARN">
@@ -40,33 +39,23 @@
     </springProfile>
 
     <!-- ========================================
-         개발 프로필: 콘솔 출력 (간소화)
-         - Docker 로그 드라이버를 통해 로그 수집
-         - Cloud Logging 비용 절감을 위해 DEBUG 로그 제거
+         개발 프로필
+         로그 레벨은 application-dev.yml에서 관리
          ======================================== -->
     <springProfile name="dev">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>
-        <logger name="com.finders" level="DEBUG"/>
-        <logger name="org.springframework.web" level="INFO"/>
-        <logger name="org.hibernate.SQL" level="WARN"/>
-        <logger name="org.hibernate.orm.jdbc.bind" level="WARN"/>
-        <logger name="org.springframework.data.redis" level="WARN"/>
-        <logger name="io.lettuce.core" level="WARN"/>
     </springProfile>
 
     <!-- ========================================
-         운영 프로필: 콘솔 출력 (최소화)
-         - Docker gcplogs가 GCP Cloud Logging으로 전송
+         운영 프로필
+         로그 레벨은 application-prod.yml에서 관리
          ======================================== -->
     <springProfile name="prod">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>
-        <logger name="com.finders" level="INFO"/>
-        <logger name="org.springframework.web" level="WARN"/>
-        <logger name="org.hibernate" level="WARN"/>
     </springProfile>
 
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -39,16 +39,20 @@
     </springProfile>
 
     <!-- ========================================
-         개발 프로필: 콘솔 출력 (상세)
-         - Docker gcplogs가 GCP Cloud Logging으로 전송
+         개발 프로필: 콘솔 출력 (간소화)
+         - Docker 로그 드라이버를 통해 로그 수집
+         - Cloud Logging 비용 절감을 위해 DEBUG 로그 제거
          ======================================== -->
     <springProfile name="dev">
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>
-        <logger name="com.finders" level="DEBUG"/>
+        <logger name="com.finders" level="INFO"/>
         <logger name="org.springframework.web" level="INFO"/>
-        <logger name="org.hibernate.SQL" level="DEBUG"/>
+        <logger name="org.hibernate.SQL" level="WARN"/>
+        <logger name="org.hibernate.orm.jdbc.bind" level="WARN"/>
+        <logger name="org.springframework.data.redis" level="WARN"/>
+        <logger name="io.lettuce.core" level="WARN"/>
     </springProfile>
 
     <!-- ========================================


### PR DESCRIPTION
## Summary

GCP Cloud Logging 비용 폭증(₩230,000+)의 근본 원인인 3중 로그 증폭 구조를 수정합니다.

## Changes

- `logback-spring.xml`: dev 프로필 Hibernate SQL/Redis/Lettuce 로거 DEBUG → WARN으로 하향
- `application-dev.yml`: 모든 DEBUG 레벨 로거(Hibernate, Redis, Lettuce) WARN으로 변경
- `application.yml`: `format_sql: true` → `false` (1 SQL = 18 Cloud Logging 엔트리 증폭 차단), `com.finders` DEBUG → INFO
- `docker-compose.dev.yml`: `gcplogs` 드라이버 → `json-file` (10m/3 rotation) 전환으로 Cloud Logging 직접 전송 차단
- `docker-compose.prod.yml`: gcplogs 유지 (prod logback이 이미 WARN 수준이므로 안전)

## Type of Change

- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues

Fixes #481

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Additional Notes

### 근본 원인 분석 (3-Layer 증폭 체인)

| Layer | 원인 | 증폭 배수 |
|-------|------|-----------|
| Application Config | logback + application-dev.yml 모두 Hibernate/Redis/Lettuce DEBUG | 기본 로그량 x50+ |
| SQL Format | `format_sql: true` → 1 SQL이 ~18줄로 포맷 → gcplogs가 각 줄을 별도 엔트리로 전송 | x18 |
| Docker Driver | `gcplogs` 드라이버가 모든 stdout → Cloud Logging 직접 전송 | x1 (전량 전송) |

### 비용 타임라인

- 2/14: 50GB 무료 티어 소진 → 과금 시작
- 2/15~17: ₩230,000+ 과금
- 2/17 21:35 KST: 예산 초과로 VM 자동 종료

### prod 환경 안전성

`docker-compose.prod.yml`은 gcplogs를 유지합니다:
- `logback-spring.xml` prod 프로필이 이미 `org.hibernate: WARN` 설정
- `format_sql: false`로 전환했으므로 SQL 포맷 증폭 없음
- prod 로그는 Cloud Logging에 수집되어야 운영 모니터링 가능