### PR TITLE
[CHORE] TF State 버킷 파라미터화 (#488)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Load Deploy Config from Terraform
         run: |
-          gcloud storage cp gs://finders-487717-tf-state/deploy-config.json /tmp/deploy-config.json
+          gcloud storage cp gs://${{ secrets.TF_STATE_BUCKET }}/deploy-config.json /tmp/deploy-config.json
           echo "GCE_NAME=$(jq -r .gce_name /tmp/deploy-config.json)" >> $GITHUB_ENV
           echo "GCE_ZONE=$(jq -r .gce_zone /tmp/deploy-config.json)" >> $GITHUB_ENV
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Load Deploy Config from Terraform
         run: |
-          gcloud storage cp gs://finders-487717-tf-state/deploy-config.json /tmp/deploy-config.json
+          gcloud storage cp gs://${{ secrets.TF_STATE_BUCKET }}/deploy-config.json /tmp/deploy-config.json
           echo "GCE_NAME=$(jq -r .gce_name /tmp/deploy-config.json)" >> $GITHUB_ENV
           echo "GCE_ZONE=$(jq -r .gce_zone /tmp/deploy-config.json)" >> $GITHUB_ENV
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -45,7 +45,7 @@ jobs:
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
       
       - name: Download Terraform Variables
-        run: gcloud storage cp gs://finders-487717-tf-state/terraform.tfvars terraform.tfvars
+        run: gcloud storage cp gs://${{ secrets.TF_STATE_BUCKET }}/terraform.tfvars terraform.tfvars
       
       - name: Terraform Format Check
         id: fmt
@@ -54,7 +54,7 @@ jobs:
       
       - name: Terraform Init
         id: init
-        run: terraform init
+        run: terraform init -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}"
       
       - name: Terraform Validate
         id: validate
@@ -119,4 +119,4 @@ jobs:
         if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
         run: |
           terraform output -raw deploy_config > /tmp/deploy-config.json
-          gcloud storage cp /tmp/deploy-config.json gs://finders-487717-tf-state/deploy-config.json
+          gcloud storage cp /tmp/deploy-config.json gs://${{ secrets.TF_STATE_BUCKET }}/deploy-config.json

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@
 | [GCP_LOGGING_GUIDE.md](infra/GCP_LOGGING_GUIDE.md) | GCP Cloud Logging 확인 가이드 | DevOps |
 | [IAC_TERRAFORM_INTRO.md](infra/IAC_TERRAFORM_INTRO.md) | IaC/Terraform 개념 학습 | 모든 개발자 |
 | [TERRAFORM_OPERATIONS.md](infra/TERRAFORM_OPERATIONS.md) | Terraform 운영 가이드 | DevOps |
+| [GCP_PROJECT_MIGRATION_RUNBOOK.md](infra/GCP_PROJECT_MIGRATION_RUNBOOK.md) | GCP 프로젝트 마이그레이션 런북 | DevOps |
 
 ## 🤝 Contributing
 

--- a/docs/infra/GCP_PROJECT_MIGRATION_RUNBOOK.md
+++ b/docs/infra/GCP_PROJECT_MIGRATION_RUNBOOK.md
@@ -1,0 +1,63 @@
+# GCP 프로젝트 마이그레이션 런북
+
+Finders 인프라를 다른 GCP 프로젝트로 이전할 때 코드 수정 없이 GitHub Secrets 값만 교체하는 운영 절차입니다.
+
+## 목적
+
+- Terraform backend bucket을 코드에서 분리해 마이그레이션 시 코드 변경을 없앱니다.
+- CI/CD가 참조하는 상태 버킷을 `TF_STATE_BUCKET` 하나로 통일합니다.
+
+## 사전 조건
+
+- 대상 GCP 프로젝트에 Terraform state 버킷이 생성되어 있어야 합니다.
+- GitHub Actions WIF 서비스 계정이 대상 프로젝트/버킷에 접근 가능해야 합니다.
+- `terraform.tfvars`가 대상 프로젝트 값으로 준비되어 있어야 합니다.
+
+## GitHub Secrets 교체 항목
+
+마이그레이션 시 아래 4개 시크릿만 변경합니다.
+
+1. `GCP_PROJECT_ID`
+2. `WIF_PROVIDER`
+3. `WIF_SERVICE_ACCOUNT`
+4. `TF_STATE_BUCKET`
+
+## 단계별 절차
+
+### 1) 대상 프로젝트 준비
+
+```bash
+gcloud config set project <NEW_PROJECT_ID>
+gcloud storage buckets create gs://<NEW_PROJECT_ID>-tf-state --location=asia-northeast3
+```
+
+### 2) terraform.tfvars 업로드
+
+```bash
+cd infra
+gcloud storage cp terraform.tfvars gs://<NEW_PROJECT_ID>-tf-state/terraform.tfvars
+```
+
+### 3) GitHub Secrets 업데이트
+
+- GitHub Repository Settings -> Secrets and variables -> Actions
+- 위 4개 시크릿을 대상 프로젝트 값으로 교체
+
+### 4) 검증
+
+1. `develop` 대상 PR에서 Terraform workflow가 `init/plan` 성공하는지 확인
+2. `develop` 머지 후 push 이벤트에서 Terraform `apply`가 성공하는지 확인
+3. 배포 워크플로우가 `deploy-config.json`을 정상 로드하는지 확인
+
+## 롤백 절차
+
+이상 발생 시 이전 프로젝트의 4개 시크릿 값으로 되돌리고 Terraform workflow를 재실행합니다.
+
+## 체크리스트
+
+- [ ] 대상 프로젝트 state 버킷 생성
+- [ ] `terraform.tfvars` 업로드
+- [ ] GitHub Secrets 4개 교체
+- [ ] Terraform PR plan 성공
+- [ ] develop merge 후 apply 성공
+- [ ] deploy/dev-deploy 파이프라인 정상 동작

--- a/docs/infra/README.md
+++ b/docs/infra/README.md
@@ -11,6 +11,7 @@
 | [GCP_LOGGING_GUIDE.md](./GCP_LOGGING_GUIDE.md) | GCP Cloud Logging 확인 가이드 | DevOps |
 | [IAC_TERRAFORM_INTRO.md](./IAC_TERRAFORM_INTRO.md) | IaC/Terraform 개념 학습 | 모든 개발자 |
 | [TERRAFORM_OPERATIONS.md](./TERRAFORM_OPERATIONS.md) | Terraform 운영 가이드 (plan/apply, 안전 수칙) | DevOps |
+| [GCP_PROJECT_MIGRATION_RUNBOOK.md](./GCP_PROJECT_MIGRATION_RUNBOOK.md) | GCP 프로젝트 마이그레이션 런북 (Secrets 기반 전환) | DevOps |
 
 ---
 
@@ -111,7 +112,8 @@ docs/
 │   ├─ SECRET_MANAGEMENT.md       (비밀 정보 관리)
 │   ├─ GCP_LOGGING_GUIDE.md       (로깅)
 │   ├─ IAC_TERRAFORM_INTRO.md     (IaC/Terraform 개념)
-│   └─ TERRAFORM_OPERATIONS.md    (Terraform 운영)
+│   ├─ TERRAFORM_OPERATIONS.md    (Terraform 운영)
+│   └─ GCP_PROJECT_MIGRATION_RUNBOOK.md (프로젝트 마이그레이션 런북)
 │
 └─ architecture/
     ├─ INFRASTRUCTURE.md          (전체 인프라 아키텍처)

--- a/docs/infra/TERRAFORM_OPERATIONS.md
+++ b/docs/infra/TERRAFORM_OPERATIONS.md
@@ -112,10 +112,10 @@ terraform force-unlock <LOCK_ID>
 
 ```bash
 # GCS 버킷에서 이전 버전 확인
-gcloud storage ls -l gs://finders-487717-tf-state/terraform/state/
+gcloud storage ls -l gs://<TF_STATE_BUCKET>/terraform/state/
 
 # 이전 버전 다운로드
-gcloud storage cp gs://finders-487717-tf-state/terraform/state/default.tfstate#<VERSION> ./terraform.tfstate
+gcloud storage cp gs://<TF_STATE_BUCKET>/terraform/state/default.tfstate#<VERSION> ./terraform.tfstate
 
 # State 복구
 cd infra
@@ -172,7 +172,7 @@ cp terraform.tfvars.example terraform.tfvars
 
 ```bash
 cd infra
-terraform init
+terraform init -backend-config="bucket=<TF_STATE_BUCKET>"
 terraform plan  # 변경사항 없어야 함 (No changes)
 ```
 
@@ -187,7 +187,10 @@ terraform plan  # 변경사항 없어야 함 (No changes)
 **해결**:
 ```bash
 # 권한 확인
-gcloud storage buckets get-iam-policy gs://finders-487717-tf-state
+gcloud storage buckets get-iam-policy gs://<TF_STATE_BUCKET>
+
+# 또는 환경 변수 기반
+gcloud storage buckets get-iam-policy gs://$TF_STATE_BUCKET
 ```
 
 ### "Error: Resource already exists"
@@ -229,6 +232,7 @@ terraform plan     # drift 확인
 - [Google Provider 문서](https://registry.terraform.io/providers/hashicorp/google/latest/docs)
 - [Cloudflare Provider 문서](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs)
 - [IaC/Terraform 개념 학습](./IAC_TERRAFORM_INTRO.md)
+- [GCP 프로젝트 마이그레이션 런북](./GCP_PROJECT_MIGRATION_RUNBOOK.md)
 - [인프라 아키텍처](../architecture/INFRASTRUCTURE.md)
 
 ---

--- a/infra/backend.tf
+++ b/infra/backend.tf
@@ -1,10 +1,11 @@
 # Backend configuration for GCS
-# State stored in finders-487717-tf-state bucket (created manually before terraform init)
-# DO NOT manage this bucket with Terraform — circular dependency
+# State bucket is created manually before terraform init — NOT managed by Terraform (circular dependency)
+# Bucket name is injected at init time via -backend-config flag:
+#   terraform init -backend-config="bucket=<PROJECT_ID>-tf-state"
+# CI/CD uses TF_STATE_BUCKET GitHub Secret for the bucket name.
 
 terraform {
   backend "gcs" {
-    bucket = "finders-487717-tf-state"
     prefix = "terraform/state"
   }
 }


### PR DESCRIPTION
## Summary

GCP 프로젝트 마이그레이션 시 코드 변경 없이 GitHub Secrets만으로 전환 가능하도록 TF State 버킷 참조를 파라미터화합니다.

**변경 전**: 프로젝트 ID가 5곳에 하드코딩 → 마이그레이션마다 코드 수정 필요
**변경 후**: GitHub Secrets 4개만 변경하면 마이그레이션 완료 (코드 변경 0)

## Changes

- `infra/backend.tf`: partial backend config 적용 — 하드코딩된 버킷명 제거, `terraform init -backend-config="bucket=..."` 방식으로 전환
- `.github/workflows/terraform.yml`: `TF_STATE_BUCKET` Secret으로 GCS 버킷 참조 파라미터화 (tfvars 다운로드, terraform init, deploy-config 업로드)
- `.github/workflows/deploy.yml`: `TF_STATE_BUCKET` Secret으로 deploy-config.json 경로 파라미터화
- `.github/workflows/deploy-dev.yml`: 동일
- `TF_STATE_BUCKET` GitHub Secret 설정 완료 (`finders-487717-tf-state`)

## Type of Change

- [x] Chore (빌드, 설정 등 기타 변경)

## Related Issues

Closes #488

## Checklist

- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시) — N/A (인프라 설정 변경)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다 — N/A

## Additional Notes

### 마이그레이션 시 필요한 GitHub Secrets (4개)

| Secret | 설명 |
|--------|------|
| `GCP_PROJECT_ID` | 새 GCP 프로젝트 ID |
| `TF_STATE_BUCKET` | `${NEW_PROJECT}-tf-state` |
| `WIF_PROVIDER` | WIF provider 전체 경로 |
| `WIF_SERVICE_ACCOUNT` | `terraform-ci@${NEW_PROJECT}.iam...` |

### ⚠️ 주의: 이 PR 머지 후 첫 Terraform CI

이 PR이 머지되면 `terraform.yml`이 `TF_STATE_BUCKET` Secret을 사용합니다. 
Secret은 이미 설정되어 있으므로 (`finders-487717-tf-state`) 정상 동작합니다.

로컬에서 Terraform 실행 시:
```bash
terraform init -backend-config="bucket=finders-487717-tf-state"
```