### PR TITLE
[FIX] Terraform Apply 실패 복구 (Cloud Run taint/deletion_protection) (#490)

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -59,6 +59,10 @@ jobs:
       - name: Terraform Validate
         id: validate
         run: terraform validate -no-color
+
+      - name: Recover tainted Cloud Run state
+        if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
+        run: terraform untaint google_cloud_run_v2_service.img_resizer || true
       
       - name: Terraform Plan
         id: plan

--- a/infra/cloudrun.tf
+++ b/infra/cloudrun.tf
@@ -1,8 +1,9 @@
 resource "google_cloud_run_v2_service" "img_resizer" {
-  project  = var.project_id
-  location = var.region
-  name     = "img-resizer"
-  ingress  = "INGRESS_TRAFFIC_ALL"
+  project             = var.project_id
+  location            = var.region
+  name                = "img-resizer"
+  ingress             = "INGRESS_TRAFFIC_ALL"
+  deletion_protection = false
 
   template {
     scaling {
@@ -56,5 +57,4 @@ resource "google_cloud_run_v2_service" "img_resizer" {
     ]
   }
 }
-
 


### PR DESCRIPTION
## Summary
- develop push 시 Terraform Apply가 `google_cloud_run_v2_service.img_resizer` tainted 상태로 교체를 시도하며 실패하던 문제를 복구합니다.
- Cloud Run 리소스에 `deletion_protection = false`를 명시해 Terraform 설정과 실제 동작을 일치시킵니다.
- develop push 이벤트에서만 tainted 상태 복구를 수행해 잔존 taint로 인한 강제 교체/삭제 시도를 방지합니다.

## Changes
- `infra/cloudrun.tf`
  - `deletion_protection = false` 추가
- `.github/workflows/terraform.yml`
  - develop push 이벤트에서 `terraform untaint google_cloud_run_v2_service.img_resizer || true` 실행 step 추가
- 실패 런 기준 재현/원인 반영
  - https://github.com/Finders-Official/BE/actions/runs/22113461945/job/63915368777?pr=485

## Type of Change
- [x] Bug fix (기존 기능에 영향을 주지 않는 버그 수정)
- [ ] New feature (기존 기능에 영향을 주지 않는 새로운 기능 추가)
- [ ] Breaking change (기존 기능에 영향을 주는 수정)
- [ ] Refactoring (기능 변경 없는 코드 개선)
- [ ] Documentation (문서 수정)
- [ ] Chore (빌드, 설정 등 기타 변경)
- [ ] Release (develop → main 배포)

## Related Issues
- Closes #490

## Checklist
- [x] 코드 컨벤션을 준수했습니다 (docs/CONVENTIONS.md 참고)
- [x] 로컬에서 빌드가 정상적으로 완료됩니다
- [ ] 새로운 기능에 대한 테스트를 작성했습니다 (해당시)
- [ ] API 변경이 있다면 Swagger 문서가 업데이트 되었습니다

## Screenshots (Optional)
-

## Additional Notes
- 로컬 검증: `terraform -chdir=infra fmt -check -recursive`, `terraform -chdir=infra init -backend=false`, `terraform -chdir=infra validate -no-color` 통과
- 이 변경은 Cloud Run을 새로 Terraform에 편입하는 작업이 아니라, 기존 Terraform 관리 리소스의 tainted/deletion_protection 불일치 상태를 복구하기 위한 수정입니다.